### PR TITLE
Proposals

### DIFF
--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,6 +1,5 @@
 import { ProposalData } from "../../../../daoData/useProposals";
 import { useState, useEffect } from "react";
-import { BigNumber } from "ethers";
 import { Link } from "react-router-dom";
 
 function ProposalCard({ proposal }: { proposal: ProposalData }) {
@@ -21,7 +20,7 @@ function ProposalCard({ proposal }: { proposal: ProposalData }) {
       ?.add(proposal.againstVotes)
       .add(proposal.abstainVotes);
 
-    if (totalVotes.eq(BigNumber.from("0"))) {
+    if (totalVotes.eq(0)) {
       setForVotesPercent(0);
       setAgainstVotesPercent(0);
       setAbstainVotesPercent(0);
@@ -30,19 +29,19 @@ function ProposalCard({ proposal }: { proposal: ProposalData }) {
 
     setForVotesPercent(
       proposal.forVotes
-        .mul(BigNumber.from("1000000"))
+        .mul(1000000)
         .div(totalVotes)
         .toNumber() / 10000
     );
     setAgainstVotesPercent(
       proposal.forVotes
-        .mul(BigNumber.from("1000000"))
+        .mul(1000000)
         .div(totalVotes)
         .toNumber() / 10000
     );
     setAbstainVotesPercent(
       proposal.abstainVotes
-        .mul(BigNumber.from("1000000"))
+        .mul(1000000)
         .div(totalVotes)
         .toNumber() / 10000
     );

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -4,17 +4,12 @@ import { Link } from "react-router-dom";
 function ProposalCard({ proposal }: { proposal: ProposalData }) {
 
   return (
+    <Link to={`proposals/${proposal.number}`} className="underline">
     <div className="flex flex-col bg-gray-300 m-2 max-w-lg">
       <div>Proposal #{proposal.number}</div>
-      <div>For: {proposal.forVotesPercent}%</div>
-      <div>Against: {proposal.againstVotesPercent}%</div>
-      <div>Abstain: {proposal.abstainVotesPercent}%</div>
-      <div className="m-4">
-        <Link to={`proposals/${proposal.number}`} className="underline">
-          View Proposal
-        </Link>
-      </div>
+      <div>{proposal.description}</div>
     </div>
+    </Link>
   );
 }
 

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,24 +1,16 @@
-import { useState, useEffect } from "react";
-import { useParams, useLocation, Link } from "react-router-dom";
-import { BigNumber } from "ethers";
+import { ProposalData } from "../../../../daoData/useProposals";
 
 function ProposalCard({
-  number,
-  yesVotes,
-  noVotes,
-  abstainVotes,
+  proposal
 }: {
-  number: number;
-  yesVotes: BigNumber;
-  noVotes: BigNumber;
-  abstainVotes: BigNumber;
+  proposal: ProposalData
 }) {
   return (
-    <div className="flex flex-col">
-      <div>New Proposal #{number}</div>
-      <div>Yes Votes: {yesVotes.toString()}</div>
-      <div>No Votes: {noVotes.toString()}</div>
-      <div>Abstain Votes: {abstainVotes.toString()}</div>
+    <div className="flex flex-col bg-gray-300 m-2 max-w-lg">
+      <div>Proposal #{proposal.number}</div>
+      <div>For: {proposal.forVotes?.toString()}</div>
+      <div>Against: {proposal.againstVotes?.toString()}</div>
+      <div>Abstain: {proposal.abstainVotes?.toString()}</div>
     </div>
   );
 }

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+import { useParams, useLocation, Link } from "react-router-dom";
+import { BigNumber } from "ethers";
+
+function ProposalCard({
+  number,
+  yesVotes,
+  noVotes,
+  abstainVotes,
+}: {
+  number: number;
+  yesVotes: BigNumber;
+  noVotes: BigNumber;
+  abstainVotes: BigNumber;
+}) {
+  return (
+    <div className="flex flex-col">
+      <div>New Proposal #{number}</div>
+      <div>Yes Votes: {yesVotes.toString()}</div>
+      <div>No Votes: {noVotes.toString()}</div>
+      <div>Abstain Votes: {abstainVotes.toString()}</div>
+    </div>
+  );
+}
+
+export default ProposalCard;

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,14 +1,26 @@
 import { ProposalData } from "../../../../daoData/useProposals";
+import useDisplayName from "../../../../hooks/useDisplayName";
 import { Link } from "react-router-dom";
+import { useEffect } from "react";
 
 function ProposalCard({ proposal }: { proposal: ProposalData }) {
+  const proposerDisplayName = useDisplayName(proposal.proposer);
+
+  useEffect(() => {
+    console.log(proposal);
+  }, [proposal]);
 
   return (
-    <Link to={`proposals/${proposal.number}`} className="underline">
-    <div className="flex flex-col bg-gray-300 m-2 max-w-lg">
-      <div>Proposal #{proposal.number}</div>
-      <div>{proposal.description}</div>
-    </div>
+    <Link to={`proposals/${proposal.number}`}>
+      <div className="flex flex-col bg-gray-300 mx-2 max-w-lg py-2">
+        <div className="flex flex-row mx-1">
+          <div className="mx-1">{proposal.stateString}</div>
+          <div className="mx-1">#{proposal.number}</div>
+          <div className="mx-1">{proposal.startTimeString} - {proposal.endTimeString}</div>
+        </div>
+        <div className="mx-2">{proposal.description}</div>
+        <div className="mx-2">Created by {proposerDisplayName}</div>
+      </div>
     </Link>
   );
 }

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,58 +1,14 @@
 import { ProposalData } from "../../../../daoData/useProposals";
-import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 
 function ProposalCard({ proposal }: { proposal: ProposalData }) {
-  const [forVotesPercent, setForVotesPercent] = useState<number>();
-  const [againstVotesPercent, setAgainstVotesPercent] = useState<number>();
-  const [abstainVotesPercent, setAbstainVotesPercent] = useState<number>();
-
-  useEffect(() => {
-    if (
-      proposal.forVotes === undefined ||
-      proposal.againstVotes === undefined ||
-      proposal.abstainVotes === undefined
-    ) {
-      return;
-    }
-
-    const totalVotes = proposal.forVotes
-      ?.add(proposal.againstVotes)
-      .add(proposal.abstainVotes);
-
-    if (totalVotes.eq(0)) {
-      setForVotesPercent(0);
-      setAgainstVotesPercent(0);
-      setAbstainVotesPercent(0);
-      return;
-    }
-
-    setForVotesPercent(
-      proposal.forVotes
-        .mul(1000000)
-        .div(totalVotes)
-        .toNumber() / 10000
-    );
-    setAgainstVotesPercent(
-      proposal.forVotes
-        .mul(1000000)
-        .div(totalVotes)
-        .toNumber() / 10000
-    );
-    setAbstainVotesPercent(
-      proposal.abstainVotes
-        .mul(1000000)
-        .div(totalVotes)
-        .toNumber() / 10000
-    );
-  }, [proposal]);
 
   return (
     <div className="flex flex-col bg-gray-300 m-2 max-w-lg">
       <div>Proposal #{proposal.number}</div>
-      <div>For: {forVotesPercent}%</div>
-      <div>Against: {againstVotesPercent}%</div>
-      <div>Abstain: {abstainVotesPercent}%</div>
+      <div>For: {proposal.forVotesPercent}%</div>
+      <div>Against: {proposal.againstVotesPercent}%</div>
+      <div>Abstain: {proposal.abstainVotesPercent}%</div>
       <div className="m-4">
         <Link to={`proposals/${proposal.number}`} className="underline">
           View Proposal

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,34 +1,51 @@
 import { ProposalData } from "../../../../daoData/useProposals";
 import { useState, useEffect } from "react";
 import { BigNumber } from "ethers";
+import { Link } from "react-router-dom";
 
-function ProposalCard({
-  proposal
-}: {
-  proposal: ProposalData
-}) {
+function ProposalCard({ proposal }: { proposal: ProposalData }) {
   const [forVotesPercent, setForVotesPercent] = useState<number>();
   const [againstVotesPercent, setAgainstVotesPercent] = useState<number>();
   const [abstainVotesPercent, setAbstainVotesPercent] = useState<number>();
 
   useEffect(() => {
-    if(proposal.forVotes === undefined || proposal.againstVotes === undefined || proposal.abstainVotes === undefined) {
+    if (
+      proposal.forVotes === undefined ||
+      proposal.againstVotes === undefined ||
+      proposal.abstainVotes === undefined
+    ) {
       return;
     }
 
-    const totalVotes = proposal.forVotes?.add(proposal.againstVotes).add(proposal.abstainVotes);
+    const totalVotes = proposal.forVotes
+      ?.add(proposal.againstVotes)
+      .add(proposal.abstainVotes);
 
-    if(totalVotes.eq(BigNumber.from("0"))) {
+    if (totalVotes.eq(BigNumber.from("0"))) {
       setForVotesPercent(0);
       setAgainstVotesPercent(0);
       setAbstainVotesPercent(0);
       return;
     }
 
-    setForVotesPercent((proposal.forVotes.mul(BigNumber.from("1000000")).div(totalVotes).toNumber()) / 10000);
-    setAgainstVotesPercent((proposal.forVotes.mul(BigNumber.from("1000000")).div(totalVotes).toNumber()) / 10000);
-    setAbstainVotesPercent((proposal.abstainVotes.mul(BigNumber.from("1000000")).div(totalVotes).toNumber()) / 10000);
-
+    setForVotesPercent(
+      proposal.forVotes
+        .mul(BigNumber.from("1000000"))
+        .div(totalVotes)
+        .toNumber() / 10000
+    );
+    setAgainstVotesPercent(
+      proposal.forVotes
+        .mul(BigNumber.from("1000000"))
+        .div(totalVotes)
+        .toNumber() / 10000
+    );
+    setAbstainVotesPercent(
+      proposal.abstainVotes
+        .mul(BigNumber.from("1000000"))
+        .div(totalVotes)
+        .toNumber() / 10000
+    );
   }, [proposal]);
 
   return (
@@ -37,6 +54,11 @@ function ProposalCard({
       <div>For: {forVotesPercent}%</div>
       <div>Against: {againstVotesPercent}%</div>
       <div>Abstain: {abstainVotesPercent}%</div>
+      <div className="m-4">
+        <Link to={`proposals/${proposal.number}`} className="underline">
+          View Proposal
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,14 +1,9 @@
 import { ProposalData } from "../../../../daoData/useProposals";
 import useDisplayName from "../../../../hooks/useDisplayName";
 import { Link } from "react-router-dom";
-import { useEffect } from "react";
 
 function ProposalCard({ proposal }: { proposal: ProposalData }) {
   const proposerDisplayName = useDisplayName(proposal.proposer);
-
-  useEffect(() => {
-    console.log(proposal);
-  }, [proposal]);
 
   return (
     <Link to={`proposals/${proposal.number}`}>

--- a/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalCard.tsx
@@ -1,16 +1,42 @@
 import { ProposalData } from "../../../../daoData/useProposals";
+import { useState, useEffect } from "react";
+import { BigNumber } from "ethers";
 
 function ProposalCard({
   proposal
 }: {
   proposal: ProposalData
 }) {
+  const [forVotesPercent, setForVotesPercent] = useState<number>();
+  const [againstVotesPercent, setAgainstVotesPercent] = useState<number>();
+  const [abstainVotesPercent, setAbstainVotesPercent] = useState<number>();
+
+  useEffect(() => {
+    if(proposal.forVotes === undefined || proposal.againstVotes === undefined || proposal.abstainVotes === undefined) {
+      return;
+    }
+
+    const totalVotes = proposal.forVotes?.add(proposal.againstVotes).add(proposal.abstainVotes);
+
+    if(totalVotes.eq(BigNumber.from("0"))) {
+      setForVotesPercent(0);
+      setAgainstVotesPercent(0);
+      setAbstainVotesPercent(0);
+      return;
+    }
+
+    setForVotesPercent((proposal.forVotes.mul(BigNumber.from("1000000")).div(totalVotes).toNumber()) / 10000);
+    setAgainstVotesPercent((proposal.forVotes.mul(BigNumber.from("1000000")).div(totalVotes).toNumber()) / 10000);
+    setAbstainVotesPercent((proposal.abstainVotes.mul(BigNumber.from("1000000")).div(totalVotes).toNumber()) / 10000);
+
+  }, [proposal]);
+
   return (
     <div className="flex flex-col bg-gray-300 m-2 max-w-lg">
       <div>Proposal #{proposal.number}</div>
-      <div>For: {proposal.forVotes?.toString()}</div>
-      <div>Against: {proposal.againstVotes?.toString()}</div>
-      <div>Abstain: {proposal.abstainVotes?.toString()}</div>
+      <div>For: {forVotesPercent}%</div>
+      <div>Against: {againstVotesPercent}%</div>
+      <div>Abstain: {abstainVotesPercent}%</div>
     </div>
   );
 }

--- a/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+import EtherscanLink from "../../../ui/EtherscanLink";
+import { useDAOData } from "../../../../daoData";
+import H1 from "../../../ui/H1";
+
+function ProposalsList({ address }: { address: string }) {
+  const [{ name, accessControlAddress, moduleAddresses }, setDAOAddress] =
+    useDAOData();
+
+  useEffect(() => {
+    setDAOAddress(address);
+  }, [address, setDAOAddress]);
+
+  return (
+    <div>
+      <H1>
+        <EtherscanLink address={address}>
+          <span className="break-all">{address}</span>
+        </EtherscanLink>{" "}
+        Proposal List
+      </H1>
+    </div>
+  );
+}
+
+export default ProposalsList;

--- a/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-
 import EtherscanLink from "../../../ui/EtherscanLink";
 import { useDAOData } from "../../../../daoData";
 import H1 from "../../../ui/H1";
@@ -7,10 +5,6 @@ import ProposalCard from "./ProposalCard";
 
 function ProposalsList({ address }: { address: string }) {
   const [{ proposals }] = useDAOData();
-
-  useEffect(() => {
-    console.log("PROPOSALS: ", proposals);
-  }, [proposals]);
 
   return (
     <div>

--- a/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
@@ -1,7 +1,7 @@
 import { useDAOData } from "../../../../daoData";
 import ProposalCard from "./ProposalCard";
 
-function ProposalsList({ address }: { address: string }) {
+function ProposalsList() {
   const [{ proposals }] = useDAOData();
 
   return (

--- a/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
@@ -1,24 +1,14 @@
-import EtherscanLink from "../../../ui/EtherscanLink";
 import { useDAOData } from "../../../../daoData";
-import H1 from "../../../ui/H1";
 import ProposalCard from "./ProposalCard";
 
 function ProposalsList({ address }: { address: string }) {
   const [{ proposals }] = useDAOData();
 
   return (
-    <div>
-      <H1>
-        <EtherscanLink address={address}>
-          <span className="break-all">{address}</span>
-        </EtherscanLink>{" "}
-        Proposal List
-        <div className="grid grid-cols-3 gap-4">
-        {proposals?.map((proposal) => (
-          <ProposalCard key={proposal.number} proposal={proposal} />
-        ))}
-        </div>
-      </H1>
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {proposals?.map((proposal) => (
+        <ProposalCard key={proposal.number} proposal={proposal} />
+      ))}
     </div>
   );
 }

--- a/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
@@ -3,14 +3,14 @@ import { useEffect } from "react";
 import EtherscanLink from "../../../ui/EtherscanLink";
 import { useDAOData } from "../../../../daoData";
 import H1 from "../../../ui/H1";
+import ProposalCard from "./ProposalCard";
 
 function ProposalsList({ address }: { address: string }) {
-  const [{ name, accessControlAddress, moduleAddresses }, setDAOAddress] =
-    useDAOData();
+  const [{ proposals }] = useDAOData();
 
   useEffect(() => {
-    setDAOAddress(address);
-  }, [address, setDAOAddress]);
+    console.log("PROPOSALS: ", proposals);
+  }, [proposals]);
 
   return (
     <div>
@@ -19,6 +19,15 @@ function ProposalsList({ address }: { address: string }) {
           <span className="break-all">{address}</span>
         </EtherscanLink>{" "}
         Proposal List
+        {proposals?.map((proposal) => (
+          <ProposalCard
+            key={proposal.number}
+            number={proposal.number}
+            yesVotes={proposal.yesVotes}
+            noVotes={proposal.noVotes}
+            abstainVotes={proposal.abstainVotes}
+          />
+        ))}
       </H1>
     </div>
   );

--- a/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalsList.tsx
@@ -19,15 +19,11 @@ function ProposalsList({ address }: { address: string }) {
           <span className="break-all">{address}</span>
         </EtherscanLink>{" "}
         Proposal List
+        <div className="grid grid-cols-3 gap-4">
         {proposals?.map((proposal) => (
-          <ProposalCard
-            key={proposal.number}
-            number={proposal.number}
-            yesVotes={proposal.yesVotes}
-            noVotes={proposal.noVotes}
-            abstainVotes={proposal.abstainVotes}
-          />
+          <ProposalCard key={proposal.number} proposal={proposal} />
         ))}
+        </div>
       </H1>
     </div>
   );

--- a/src/components/DAOs/DAO/Proposals/index.tsx
+++ b/src/components/DAOs/DAO/Proposals/index.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, useParams } from "react-router-dom";
 
 import New from "./New";
+import ProposalsList from "./ProposalsList";
 
 function Proposals({ address }: { address: string }) {
   const params = useParams();
@@ -11,6 +12,7 @@ function Proposals({ address }: { address: string }) {
 
   return (
     <Routes>
+      <Route index element={<ProposalsList address={address} />} />
       <Route path="new" element={<New address={address} />} />
     </Routes>
   );

--- a/src/components/DAOs/DAO/Proposals/index.tsx
+++ b/src/components/DAOs/DAO/Proposals/index.tsx
@@ -1,7 +1,6 @@
 import { Routes, Route, useParams } from "react-router-dom";
 
 import New from "./New";
-import ProposalsList from "./ProposalsList";
 
 function Proposals({ address }: { address: string }) {
   const params = useParams();
@@ -12,7 +11,6 @@ function Proposals({ address }: { address: string }) {
 
   return (
     <Routes>
-      <Route index element={<ProposalsList address={address} />} />
       <Route path="new" element={<New address={address} />} />
     </Routes>
   );

--- a/src/components/DAOs/DAO/Summary.tsx
+++ b/src/components/DAOs/DAO/Summary.tsx
@@ -7,9 +7,10 @@ import useIsDAO from "../../../hooks/useIsDAO";
 import SearchingDAO from "../SearchingDAO";
 import { useDAOData } from "../../../daoData";
 import H1 from "../../ui/H1";
+import ProposalCard from "./Proposals/ProposalCard";
 
 function ValidDAO({ address }: { address: string }) {
-  const [{ name, accessControlAddress }, setDAOAddress] = useDAOData();
+  const [{ name, accessControlAddress, proposals }, setDAOAddress] = useDAOData();
 
   useEffect(() => {
     setDAOAddress(address);
@@ -41,6 +42,11 @@ function ValidDAO({ address }: { address: string }) {
         </div>
         <div>name: {name}</div>
         <div>access control address: {accessControlAddress}</div>
+        <div className="grid grid-cols-3 gap-4">
+        {proposals?.map((proposal) => (
+          <ProposalCard key={proposal.number} proposal={proposal} />
+        ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/DAOs/DAO/Summary.tsx
+++ b/src/components/DAOs/DAO/Summary.tsx
@@ -16,10 +16,6 @@ function ValidDAO({ address }: { address: string }) {
     setDAOAddress(address);
   }, [address, setDAOAddress]);
 
-  useEffect(() => {
-    console.log("Proposals: ", proposals);
-  }, [proposals]);
-
   return (
     <div>
       <H1>

--- a/src/components/DAOs/DAO/Summary.tsx
+++ b/src/components/DAOs/DAO/Summary.tsx
@@ -37,7 +37,7 @@ function ValidDAO({ address }: { address: string }) {
         </div>
         <div>name: {name}</div>
         <div>access control address: {accessControlAddress}</div>
-        <ProposalsList address={address} />
+        <ProposalsList />
       </div>
     </div>
   );

--- a/src/components/DAOs/DAO/Summary.tsx
+++ b/src/components/DAOs/DAO/Summary.tsx
@@ -7,10 +7,10 @@ import useIsDAO from "../../../hooks/useIsDAO";
 import SearchingDAO from "../SearchingDAO";
 import { useDAOData } from "../../../daoData";
 import H1 from "../../ui/H1";
-import ProposalCard from "./Proposals/ProposalCard";
+import ProposalsList from "./Proposals/ProposalsList";
 
 function ValidDAO({ address }: { address: string }) {
-  const [{ name, accessControlAddress, proposals }, setDAOAddress] = useDAOData();
+  const [{ name, accessControlAddress }, setDAOAddress] = useDAOData();
 
   useEffect(() => {
     setDAOAddress(address);
@@ -31,22 +31,13 @@ function ValidDAO({ address }: { address: string }) {
           </Link>
         </div>
         <div>
-          <Link to="proposals" className="underline">
-            Proposal List
-          </Link>
-        </div>
-        <div>
           <Link to="proposals/new" className="underline">
             Create Proposal
           </Link>
         </div>
         <div>name: {name}</div>
         <div>access control address: {accessControlAddress}</div>
-        <div className="grid grid-cols-3 gap-4">
-        {proposals?.map((proposal) => (
-          <ProposalCard key={proposal.number} proposal={proposal} />
-        ))}
-        </div>
+        <ProposalsList address={address} />
       </div>
     </div>
   );

--- a/src/components/DAOs/DAO/Summary.tsx
+++ b/src/components/DAOs/DAO/Summary.tsx
@@ -16,6 +16,10 @@ function ValidDAO({ address }: { address: string }) {
     setDAOAddress(address);
   }, [address, setDAOAddress]);
 
+  useEffect(() => {
+    console.log("Proposals: ", proposals);
+  }, [proposals]);
+
   return (
     <div>
       <H1>

--- a/src/components/DAOs/DAO/Summary.tsx
+++ b/src/components/DAOs/DAO/Summary.tsx
@@ -30,6 +30,11 @@ function ValidDAO({ address }: { address: string }) {
           </Link>
         </div>
         <div>
+          <Link to="proposals" className="underline">
+            Proposal List
+          </Link>
+        </div>
+        <div>
           <Link to="proposals/new" className="underline">
             Create Proposal
           </Link>

--- a/src/daoData/daoData.ts
+++ b/src/daoData/daoData.ts
@@ -5,11 +5,14 @@ import useDAOName from './useDAOName';
 import useAccessControlAddress from './useAccessControlAddress';
 import useAccessControlContract from './useAccessControlContract';
 import useModuleAddresses from './useModuleAddresses';
+import useProposals from './useProposals';
+import { ProposalData } from './useProposals';
 
 export interface DAOData {
   name: string | undefined,
   accessControlAddress: string | undefined,
   moduleAddresses: string[] | undefined,
+  proposals: ProposalData[] | undefined,
 };
 
 export const useDAODatas = () => {
@@ -20,11 +23,13 @@ export const useDAODatas = () => {
   const accessControlAddress = useAccessControlAddress(daoContract);
   const accessControlContract = useAccessControlContract(accessControlAddress);
   const moduleAddresses = useModuleAddresses(daoContract, accessControlContract);
+  const proposals = useProposals(moduleAddresses);
 
   const daoData: DAOData = {
     name,
     accessControlAddress,
-    moduleAddresses
+    moduleAddresses,
+    proposals
   };
 
   return [daoData, setDAOAddress] as const;

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -8,6 +8,8 @@ export type ProposalData = {
   id: BigNumber;
   startBlock: BigNumber;
   endBlock: BigNumber;
+  proposer: string;
+  description: string;
   forVotesPercent: number | undefined;
   againstVotesPercent: number | undefined;
   abstainVotesPercent: number | undefined;
@@ -62,6 +64,8 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
             id: proposalEvent.args.proposalId,
             startBlock: proposalEvent.args.startBlock,
             endBlock: proposalEvent.args.endBlock,
+            proposer: proposalEvent.args.proposer,
+            description: proposalEvent.args.description,
             forVotesPercent: undefined,
             againstVotesPercent: undefined,
             abstainVotesPercent: undefined,
@@ -118,6 +122,7 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
       calldatas: string[],
       startBlock: BigNumber,
       endBlock: BigNumber,
+      description: string,
       _: any
     ) => {
       const newProposal: ProposalData = {
@@ -125,6 +130,8 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
         id: proposalId,
         startBlock: startBlock,
         endBlock: endBlock,
+        proposer: proposer,
+        description: description,
         forVotesPercent: undefined,
         againstVotesPercent: undefined,
         abstainVotesPercent: undefined,

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -18,6 +18,7 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
   const [proposals, setProposals] = useState<ProposalData[]>([]);
   const { signerOrProvider } = useWeb3();
 
+  // Get the vote counts for a given proposal
   const getProposalVotes = useCallback(
     (proposalId: BigNumber) => {
       if (governorModule === undefined) return;
@@ -27,6 +28,7 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
     [governorModule]
   );
 
+  // Set the Governor module contract
   useEffect(() => {
     if (
       moduleAddresses === undefined ||
@@ -50,6 +52,7 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
 
     const filter = governorModule.filters.ProposalCreated();
 
+    // Get an array of all the ProposalCreated events
     governorModule
       .queryFilter(filter)
       .then((proposalEvents) => {
@@ -68,6 +71,7 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
             return newProposal;
           });
 
+          // Get the vote counts for each proposal and add them to the newProposals object
           Promise.all(newProposals.map((proposal) => (getProposalVotes(proposal.id)))).then((votes) => {
             votes.forEach((vote, index) => {
               if(vote === undefined) return;

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -10,9 +10,12 @@ export type ProposalData = {
   endBlock: BigNumber;
   startTime: Date | undefined;
   endTime: Date | undefined;
+  startTimeString: string | undefined;
+  endTimeString: string | undefined;
   proposer: string;
   description: string;
   state: number | undefined;
+  stateString: string | undefined;
   forVotesPercent: number | undefined;
   againstVotesPercent: number | undefined;
   abstainVotesPercent: number | undefined;
@@ -23,15 +26,35 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
   const [proposals, setProposals] = useState<ProposalData[]>([]);
   const { provider, signerOrProvider } = useWeb3();
 
-  const getBlockTimestamp = useCallback((blockNumber: number) => {
-    if (!provider) return;
-    return provider.getBlock(blockNumber)
-    .then((block) => {
-        console.log(block);
-        return new Date(block.timestamp * 1000);
-    });
+  const getStateString = (state: number | undefined) => {
+    if(state === 1) {
+      return "Open";
+    } else {
+      return "Closed";
+    }
+  };
 
-  }, [provider]);
+  const getTimestampString = (time: Date | undefined) => {
+    if (time === undefined) return;
+
+    return (
+      time.toLocaleDateString("en-US", { month: "short" }) +
+      " " +
+      time.toLocaleDateString("en-US", { day: "numeric" }) +
+      ", " +
+      time.toLocaleDateString("en-US", { year: "numeric" })
+    );
+  };
+
+  const getBlockTimestamp = useCallback(
+    (blockNumber: number) => {
+      if (!provider) return;
+      return provider.getBlock(blockNumber).then((block) => {
+        return new Date(block.timestamp * 1000);
+      });
+    },
+    [provider]
+  );
 
   // Get the vote counts for a given proposal
   const getProposalVotes = useCallback(
@@ -85,9 +108,12 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
             endBlock: proposalEvent.args.endBlock,
             startTime: undefined,
             endTime: undefined,
+            startTimeString: undefined,
+            endTimeString: undefined,
             proposer: proposalEvent.args.proposer,
             description: proposalEvent.args.description,
             state: undefined,
+            stateString: undefined,
             forVotesPercent: undefined,
             againstVotesPercent: undefined,
             abstainVotesPercent: undefined,
@@ -107,12 +133,14 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
             )
           ),
           Promise.all(
-            newProposals.map((proposal) => 
-              getBlockTimestamp(proposal.startBlock.toNumber()))
+            newProposals.map((proposal) =>
+              getBlockTimestamp(proposal.startBlock.toNumber())
+            )
           ),
           Promise.all(
-            newProposals.map((proposal) => 
-              getBlockTimestamp(proposal.endBlock.toNumber()))
+            newProposals.map((proposal) =>
+              getBlockTimestamp(proposal.endBlock.toNumber())
+            )
           ),
           newProposals,
         ]);
@@ -142,7 +170,10 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
 
           newProposals[index].state = state;
           newProposals[index].startTime = startTime;
-          newProposals[index].endTime = endTime;          
+          newProposals[index].endTime = endTime;
+          newProposals[index].startTimeString = getTimestampString(startTime);
+          newProposals[index].endTimeString = getTimestampString(endTime);
+          newProposals[index].stateString = getStateString(newProposals[index].state);
         });
 
         setProposals(newProposals);
@@ -177,9 +208,12 @@ const useProposals = (moduleAddresses: string[] | undefined) => {
         endBlock: endBlock,
         startTime: undefined,
         endTime: undefined,
+        startTimeString: undefined,
+        endTimeString: undefined,
         proposer: proposer,
         description: description,
         state: undefined,
+        stateString: undefined,
         forVotesPercent: undefined,
         againstVotesPercent: undefined,
         abstainVotesPercent: undefined,

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -1,0 +1,109 @@
+import { useState, useEffect } from "react";
+import { useDAOData } from "./index";
+import {
+  DAO,
+  AccessControl,
+  GovernorModule,
+  GovernorModule__factory,
+} from "../typechain-types";
+import { useWeb3 } from "../web3";
+import { BigNumber } from "ethers";
+
+export type ProposalData = {
+  number: number;
+  id: BigNumber;
+  yesVotes: BigNumber;
+  noVotes: BigNumber;
+  abstainVotes: BigNumber;
+};
+
+const useProposals = (moduleAddresses: string[] | undefined) => {
+  const [governorModule, setGovernorModule] = useState<GovernorModule>();
+  const [proposals, setProposals] = useState<ProposalData[]>([]);
+  const { signerOrProvider } = useWeb3();
+
+  useEffect(() => {
+    if (
+      moduleAddresses === undefined ||
+      moduleAddresses[1] === undefined ||
+      signerOrProvider === undefined
+    ) {
+      setGovernorModule(undefined);
+      return;
+    }
+
+    setGovernorModule(
+      GovernorModule__factory.connect(moduleAddresses[1], signerOrProvider)
+    );
+  }, [moduleAddresses, signerOrProvider]);
+
+  // Get initial proposal events
+  useEffect(() => {
+    if (governorModule === undefined) {
+      return;
+    }
+
+    const filter = governorModule.filters.ProposalCreated();
+
+    governorModule
+      .queryFilter(filter)
+      .then((proposalEvents) => {
+        setProposals(
+          proposalEvents.map((proposalEvent, index) => {
+            const newProposal: ProposalData = {
+              number: index,
+              id: proposalEvent.args.proposalId,
+              yesVotes: BigNumber.from("0"),
+              noVotes: BigNumber.from("0"),
+              abstainVotes: BigNumber.from("0"),
+            };
+
+            return newProposal;
+          })
+        );
+      })
+      .catch(console.error);
+  }, [governorModule]);
+
+  // Setup proposal events listener
+  useEffect(() => {
+    if (governorModule === undefined) {
+      return;
+    }
+
+    const filter = governorModule.filters.ProposalCreated();
+
+    const listenerCallback = (
+      proposalId: BigNumber,
+      proposer: string,
+      targets: string[],
+      values: BigNumber[],
+      signatures: string[],
+      calldatas: string[],
+      startBlock: BigNumber,
+      endBlock: BigNumber,
+      _: any
+    ) => {
+
+      const newProposal: ProposalData = {
+        number: proposals.length,
+        id: proposalId,
+        yesVotes: BigNumber.from("0"),
+        noVotes: BigNumber.from("0"),
+        abstainVotes: BigNumber.from("0")
+      }
+
+      setProposals([...proposals, newProposal]);
+    };
+
+    governorModule.on(filter, listenerCallback);
+
+    return () => {
+      governorModule.off(filter, listenerCallback);
+    };
+  }, [governorModule, proposals]);
+
+  return proposals;
+};
+
+export default useProposals;


### PR DESCRIPTION
This PR renders all proposals that have been created for a given DAO on the DAO summary page. 

A useProposals hook has been added in the data layer which gathers data from emitted events (historical and realtime), and additional data from the GovernorModule. 

This hook creates an array of ProposalData objects, one for each proposal, with the following data:

export type ProposalData = {
  number: number;
  id: BigNumber;
  startBlock: BigNumber;
  endBlock: BigNumber;
  startTime: Date | undefined;
  endTime: Date | undefined;
  startTimeString: string | undefined;
  endTimeString: string | undefined;
  proposer: string;
  description: string;
  state: number | undefined;
  stateString: string | undefined;
  forVotesPercent: number | undefined;
  againstVotesPercent: number | undefined;
  abstainVotesPercent: number | undefined;
};

The ProposalCard components still need to be styled in a future PR. Currently, the ProposalCard components render on the DAO summary page as shown in the below screenshot:

![image](https://user-images.githubusercontent.com/84364476/164816790-d4808d36-026c-4c14-8b76-a151d318b110.png)
