### PR TITLE
Breadcrumbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-scripts": "5.0.0",
         "react-toastify": "^8.2.0",
         "typescript": "^4.6.2",
+        "use-react-router-breadcrumbs": "^3.2.1",
         "util": "^0.12.4",
         "web-vitals": "^2.1.4",
         "web3modal": "^1.9.5"
@@ -15303,6 +15304,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-react-router-breadcrumbs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/use-react-router-breadcrumbs/-/use-react-router-breadcrumbs-3.2.1.tgz",
+      "integrity": "sha512-GpDhGo/A0I1ckGLER1/YZX/tgX+KOAyCGG2HgFIc0SVzQ30hTilufNdNRN3Gt+WXJW0zgn48CxxKvKSe+xA3TA==",
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-router": ">=6.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
@@ -27308,6 +27318,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-react-router-breadcrumbs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/use-react-router-breadcrumbs/-/use-react-router-breadcrumbs-3.2.1.tgz",
+      "integrity": "sha512-GpDhGo/A0I1ckGLER1/YZX/tgX+KOAyCGG2HgFIc0SVzQ30hTilufNdNRN3Gt+WXJW0zgn48CxxKvKSe+xA3TA==",
+      "requires": {}
     },
     "util": {
       "version": "0.12.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-scripts": "5.0.0",
     "react-toastify": "^8.2.0",
     "typescript": "^4.6.2",
+    "use-react-router-breadcrumbs": "^3.2.1",
     "util": "^0.12.4",
     "web-vitals": "^2.1.4",
     "web3modal": "^1.9.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import Header from './components/Header';
 import Body from './components/Body'
+import Breadcrumbs from './components/Breadcrumbs';
 
 function App() {
   return (
     <div className="flex flex-col min-h-screen font-medium">
       <Header />
       <main className="flex-grow bg-image-pattern bg-cover">
+        <Breadcrumbs />
         <div className="container pt-20">
           <Body />
         </div>

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,75 @@
+import { NavLink, useMatch, useLocation } from 'react-router-dom';
+import useBreadcrumbs, { BreadcrumbMatch } from 'use-react-router-breadcrumbs';
+
+import { useDAOData } from '../daoData';
+import RightArrow from './ui/svg/RightArrow';
+
+const DAOName = () => {
+  const [{ name }] = useDAOData();
+
+  return (
+    <span>{name || "..."}</span>
+  );
+}
+
+const ProposalId = ({ match }: { match: BreadcrumbMatch }) => {
+  const id = match.params.id;
+
+  return (
+    <span>Proposal {id}</span>
+  );
+}
+
+function Breadcrumbs() {
+  const location = useLocation();
+
+  const excludePaths: Array<string> = [];
+
+  const home = '/';
+  excludePaths.push(home);
+  const matchHome = useMatch(home);
+
+  const daos = '/daos';
+  excludePaths.push(daos);
+  const matchDaos = useMatch(daos);
+
+  const daosNew = '/daos/new';
+  excludePaths.push(daosNew);
+  const matchDaosNew = useMatch(daosNew);
+
+  const breadcrumbOptions = { excludePaths };
+  const routes = [
+    { path: '/daos/:address', breadcrumb: DAOName },
+    { path: '/daos/:address/proposals', breadcrumb: null },
+    { path: '/daos/:address/proposals/new', breadcrumb: "New Proposal" },
+    { path: '/daos/:address/proposals/:id', breadcrumb: ProposalId }
+  ];
+  const breadcrumbs = useBreadcrumbs(routes, breadcrumbOptions);
+
+  const anyExcludeMatch = [matchHome, matchDaos, matchDaosNew].some(match => match !== null);
+  if (anyExcludeMatch) {
+    return <></>;
+  }
+
+  return (
+    <div className="py-2 text-white bg-gray-600 bg-opacity-70 font-mono tracking-wider">
+      <div className="container flex">
+        {breadcrumbs.map(({ match, breadcrumb }, i) => (
+          <div key={match.pathname} className="flex">
+            {match.pathname === location.pathname
+              ? <span>{breadcrumb}</span>
+              : <NavLink className="text-gold-500" to={match.pathname}>{breadcrumb}</NavLink>
+            }
+            {i < breadcrumbs.length - 1 && (
+              <div className="mx-1">
+                <RightArrow />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Breadcrumbs;

--- a/src/components/ui/svg/LeftArrow.tsx
+++ b/src/components/ui/svg/LeftArrow.tsx
@@ -1,11 +1,9 @@
-import React from 'react'
-
 const LeftArrow = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-6 pr-1 mt-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M10.909 12 16 16.667 14.546 18 8 12l6.546-6L16 7.333 10.909 12z" fill="currentColor" />
     </svg>
-  )
+  );
 }
 
 export default LeftArrow

--- a/src/components/ui/svg/RightArrow.tsx
+++ b/src/components/ui/svg/RightArrow.tsx
@@ -1,11 +1,9 @@
-import React from 'react'
-
 const RightArrow = () => {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-6 pl-1 mt-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M13.091 12 8 7.333 9.454 6 16 12l-6.546 6L8 16.667 13.091 12z" fill="currentColor"/>
     </svg>
-  )
+  );
 }
 
 export default RightArrow


### PR DESCRIPTION
# Implements Breadcrumbs

Closes #42 

* Breadcrumbs only show up when within a loaded DAO
  * `anyExcludeMatch` captures this -- don't even show the Breadcrumb bar if any of the given locations match
* When breadcrumbs _are_ displayed, "start" them at the "loaded DAO" level (exclude `Home`, and `DAOs`)
  * `excludePaths` captures this
* Don't display certain paths (e.g. `Proposals`) when showing breadcrumbs
  * path-specific `null` breadcrumbs capture this -- e.g. `{ path: '/daos/:address/proposals', breadcrumb: null },`
* Show dynamic information in Breadcrumbs -- e.g. DAO Name instead of the DAO's address (which is in the URL)
  * custom Breadcrumb render components capture this -- e.g. `DAOName` and `ProposalId` components
* Make current path white text, previous paths gold links

No Breadcrumb 👇
![Screen Shot 2022-04-26 at 2 41 49 PM](https://user-images.githubusercontent.com/706929/165369943-2c208889-dce4-4f8d-99bb-9102be386c9c.png)

No Breadcrumb 👇
![Screen Shot 2022-04-26 at 2 42 09 PM](https://user-images.githubusercontent.com/706929/165369948-0c469aef-aaa1-417b-918a-804b6ba35ec2.png)

Just DAO Name on DAO homepage 👇
![Screen Shot 2022-04-26 at 2 42 23 PM](https://user-images.githubusercontent.com/706929/165369950-266d04cf-cdb6-481c-ae7d-2e468526816b.png)

Show "Details" on the DAO Details page 👇
![Screen Shot 2022-04-26 at 2 42 26 PM](https://user-images.githubusercontent.com/706929/165369951-13339aed-cd17-4de1-8891-afc25d20bd3e.png)

Show "New Proposal" on the New Proposal page (notice it's not `fr > Proposals > New`) 👇
![Screen Shot 2022-04-26 at 2 42 30 PM](https://user-images.githubusercontent.com/706929/165369953-5a68656f-26d3-48d2-b722-b704b6d67437.png)

Show the Proposal Number on the Proposal detail page (notice it's not `fr > Proposals > 0`) 👇
![Screen Shot 2022-04-26 at 2 42 34 PM](https://user-images.githubusercontent.com/706929/165369956-cb5698b1-b1f3-4e69-9bac-06c33e5d67c4.png)