### PR TITLE
removes mx-8

### DIFF
--- a/src/components/ui/forms/InputBox.tsx
+++ b/src/components/ui/forms/InputBox.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 const InputBox = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="bg-gray-500 rounded-lg my-4  mx-8">
+    <div className="bg-gray-500 rounded-lg my-4">
       <div className="px-4 py-4">{children}</div>
     </div>
   );


### PR DESCRIPTION
## Overview

This was going be for changing the  `mx-8` to `px-8` in `InputBox` but after looking at it and other screens. I noticed that all the other inputs have a smaller padding `px-4` in the designs so I just remove it all together

