### PR TITLE
Proposal listener fix

### DIFF
--- a/src/daoData/daoData.ts
+++ b/src/daoData/daoData.ts
@@ -41,9 +41,9 @@ export const useDAODatas = () => {
   const governorModuleContract = useGovernorModuleContract(moduleAddresses);
   const tokenContract = useTokenContract(governorModuleContract);
   const tokenData = useTokenData(tokenContract);
-  const proposals = useProposals(governorModuleContract);
   const currentBlockNumber = useCurrentBlockNumber();
   const currentTimestamp = useCurrentTimestamp(currentBlockNumber);
+  const proposals = useProposals(governorModuleContract, currentBlockNumber);
 
   const daoData: DAOData = {
     name,


### PR DESCRIPTION
This PR fixes the bug in which newly created proposals were not always added automatically to the proposals list.

This was done by checking if the proposal start block is in the future. If so, then the user vote power is set to undefined.

These changes also have the side effect of making the proposal states update automatically as new blocks are received, since currentBlockNumber is now a dependency of the useProposalsWithoutVotes hook.