### PR TITLE
Header Mobile update

### DIFF
--- a/src/components/ui/Header/HeaderMenu.tsx
+++ b/src/components/ui/Header/HeaderMenu.tsx
@@ -48,11 +48,11 @@ const HeaderMenu = () => {
             <Transition
               show={open}
               enter="transition ease-out duration-100"
-              enterFrom="transform opacity-0 scale-95"
-              enterTo="transform opacity-100 scale-100"
-              leave="transition ease-in duration-75"
-              leaveFrom="transform opacity-100 scale-100"
-              leaveTo="transform opacity-0 scale-95"
+              enterFrom="sm:transform sm:opacity-0 sm:scale-95"
+              enterTo="sm:transform sm:opacity-100 sm:scale-100"
+              leave="transition ease-in sm:duration-75"
+              leaveFrom="sm:transform sm:opacity-100 sm:scale-100"
+              leaveTo="sm:transform sm:opacity-0 sm:scale-95"
             >
               <MenuItems />
             </Transition>

--- a/src/components/ui/Header/MenuItems.tsx
+++ b/src/components/ui/Header/MenuItems.tsx
@@ -9,9 +9,10 @@ import Faq from "../svg/Faq";
 import CopyToClipboard from "../CopyToClipboard";
 import EtherscanLink from "../EtherscanLink";
 import useDisplayName from "../../../hooks/useDisplayName";
-
+import cx from "classnames";
 interface MenuItem {
   title: string;
+  className?: string;
   Icon: () => JSX.Element;
 }
 
@@ -53,18 +54,24 @@ const DISCONNECT: ActionMenuItem = {
   Icon: Disconnect,
 };
 
-const ItemWrapper = (props: { children: JSX.Element | JSX.Element[]; noHoverEffect?: boolean }) => (
-  <div className={`flex items-center justify-start gap-4 text-white p-4 ${!props.noHoverEffect ? "hover:bg-slate-200 hover:text-black" : ""}`}>{props.children}</div>
+const ItemWrapper = (props: { children: JSX.Element | JSX.Element[]; noHoverEffect?: boolean; className?: string }) => (
+  <div
+    className={cx("flex items-center justify-start gap-4 text-white p-4", {
+      "hover:bg-slate-200 hover:text-black": !props.noHoverEffect,
+    }, props.className)}
+  >
+    {props.children}
+  </div>
 );
 
-const ActionItem = ({ title, action, Icon, isVisible }: ActionMenuItem) => {
+const ActionItem = ({ title, className, action, Icon, isVisible }: ActionMenuItem) => {
   if (!isVisible) {
     return null;
   }
   return (
     <Menu.Item>
-      <button onClick={action} className="w-full">
-        <ItemWrapper>
+      <button onClick={action} className={cx("w-full", className)}>
+        <ItemWrapper className={className}>
           <Icon />
           <span>{title}</span>
         </ItemWrapper>
@@ -111,7 +118,7 @@ const MenuItems = () => {
       <div className="font-mono">
         <section>
           <AddressCopyItem account={account} />
-          <ActionItem {...DISCONNECT} isVisible={!!account} />
+          <ActionItem {...DISCONNECT} isVisible={!!account} className="text-red" />
           <ActionItem {...CONNECT_WALLET} isVisible={!account} />
         </section>
         <section className="border-t border-gray-300">

--- a/src/components/ui/Header/MenuItems.tsx
+++ b/src/components/ui/Header/MenuItems.tsx
@@ -54,7 +54,7 @@ const DISCONNECT: ActionMenuItem = {
 };
 
 const ItemWrapper = (props: { children: JSX.Element | JSX.Element[]; noHoverEffect?: boolean }) => (
-  <div className={`flex items-center gap-4 text-white p-4 ${!props.noHoverEffect ? "hover:bg-slate-200 hover:text-black" : ""}`}>{props.children}</div>
+  <div className={`flex items-center justify-start gap-4 text-white p-4 ${!props.noHoverEffect ? "hover:bg-slate-200 hover:text-black" : ""}`}>{props.children}</div>
 );
 
 const ActionItem = ({ title, action, Icon, isVisible }: ActionMenuItem) => {
@@ -106,7 +106,7 @@ const MenuItems = () => {
   return (
     <Menu.Items
       static
-      className="fixed left-0 w-full sm:absolute sm:left-auto sm:right-0 sm:w-max mt-6 pb-1 origin-top-right bg-gray-500 border border-gray-200 rounded-md shadow-menu"
+      className="fixed left-0 w-full sm:absolute z-10 sm:left-auto sm:right-0 sm:w-max mt-6 pb-1 origin-top-right bg-gray-500 border border-gray-200 rounded-md shadow-menu"
     >
       <div className="font-mono">
         <section>

--- a/src/components/ui/Header/index.tsx
+++ b/src/components/ui/Header/index.tsx
@@ -1,15 +1,15 @@
 import { Link } from "react-router-dom";
-import FractalLogo from '../svg/Logo';
+import FractalLogo from "../svg/Logo";
 import HeaderMenu from "./HeaderMenu";
 
 function Header() {
   return (
     <header className="py-4 bg-gray-600">
-      <div className="container flex flex-col sm:flex-row sm:justify-between sm:items-center">
-        <div className="mr-2 mb-4 sm:mb-0">
-          <div className="mr-2 text-3xl uppercase text-white font-bold font-mono tracking-widest">
-            <Link to="/"><FractalLogo /></Link>
-          </div>
+      <div className="container flex justify-between items-center">
+        <div className="mr-4">
+          <Link to="/">
+            <FractalLogo />
+          </Link>
         </div>
         <HeaderMenu />
       </div>


### PR DESCRIPTION
## Overview

Updates Header menu not to flicker when opening on mobile

## Changes
- Also updates Disconnect text to be red
- removes transition effect when on small screens
- keeps address/menu right aligned when on small screens

## Screenshots
![image](https://user-images.githubusercontent.com/38386583/166506172-a9a01466-baad-4982-ba60-53dbca59f805.png)

![image](https://user-images.githubusercontent.com/38386583/166506288-17b3fb81-c6fc-4ebe-9a80-a23848fb88e2.png)
