### PR TITLE
Search only with account

### DIFF
--- a/src/components/DAOs/New/index.tsx
+++ b/src/components/DAOs/New/index.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { toast } from "react-toastify";
+import { useState } from "react";
 import DAODetails from "./DAODetails";
 import TokenDetails from "./TokenDetails";
 import GovernanceDetails from "./GovernanceDetails";
@@ -11,8 +10,7 @@ import RightArrow from "../../ui/svg/RightArrow";
 import { TokenAllocation } from "../../../daoData/useDeployDAO";
 import { SecondaryButton, TextButton, PrimaryButton } from "../../ui/forms/Button";
 import H1 from "../../ui/H1";
-import { useWeb3 } from "../../../web3";
-import { connect } from "../../../web3/providers";
+import ConnectWalletToast from "../shared/ConnectWalletToast";
 
 interface StepDisplayProps {
   step: number;
@@ -74,17 +72,7 @@ const StepDisplay = ({
   return <></>;
 };
 
-const ToastContent = () => {
-  return (
-    <div className="flex flex-col items-center">
-      <div>To deploy a new Fractal</div>
-      <TextButton label="Connect Wallet" onClick={connect} />
-    </div>
-  )
-};
-
 const New = () => {
-  const { account } = useWeb3();
   const [step, setStep] = useState<number>(0);
   const [prevEnabled, setPrevEnabled] = useState<boolean>(false);
   const [nextEnabled, setNextEnabled] = useState<boolean>(false);
@@ -118,23 +106,9 @@ const New = () => {
     setPending,
   });
 
-  useEffect(() => {
-    if (account) {
-      return;
-    }
-
-    const toastId = toast(<ToastContent />, {
-      autoClose: false,
-      closeOnClick: false,
-      draggable: false,
-      progress: 1,
-    });
-
-    return () => toast.dismiss(toastId);
-  }, [account]);
-
   return (
     <div className="pb-16">
+      <ConnectWalletToast label="To deploy a new Fractal" />
       <Pending message="Creating Fractal..." pending={pending} />
       <div>
         <H1>{!daoName || daoName.trim() === "" || step === 0 ? "Configure New Fractal" : "Configure " + daoName}</H1>

--- a/src/components/DAOs/Search/DAOSearch.tsx
+++ b/src/components/DAOs/Search/DAOSearch.tsx
@@ -7,8 +7,10 @@ import Input from "../../ui/forms/Input";
 import useSearchDao from "../../../hooks/useSearchDao";
 import { PrimaryButton } from "../../ui/forms/Button";
 import ConnectWalletToast from "../shared/ConnectWalletToast";
+import { useWeb3 } from "../../../web3";
 
 function DAOSearch() {
+  const { account } = useWeb3();
   const [searchAddressInput, setSearchAddressInput] = useState("");
   const { errorMessage, loading, resetErrorState, updateSearchString } = useSearchDao();
 
@@ -50,7 +52,7 @@ function DAOSearch() {
                 />
               </div>
 
-              <PrimaryButton type="submit" label="Search" isLoading={loading} disabled={!!errorMessage || loading || !searchAddressInput.trim()} />
+              <PrimaryButton type="submit" label="Search" isLoading={loading} disabled={!!errorMessage || loading || !searchAddressInput.trim() || !account} />
             </div>
           </InputBox>
         </form>

--- a/src/components/DAOs/Search/DAOSearch.tsx
+++ b/src/components/DAOs/Search/DAOSearch.tsx
@@ -6,6 +6,7 @@ import InputBox from "../../ui/forms/InputBox";
 import Input from "../../ui/forms/Input";
 import useSearchDao from "../../../hooks/useSearchDao";
 import { PrimaryButton } from "../../ui/forms/Button";
+import ConnectWalletToast from "../shared/ConnectWalletToast";
 
 function DAOSearch() {
   const [searchAddressInput, setSearchAddressInput] = useState("");
@@ -32,6 +33,7 @@ function DAOSearch() {
 
   return (
     <div>
+      <ConnectWalletToast label="To search for a Fractal" />
       <H1>Find a Fractal</H1>
       <ContentBox>
         <form onSubmit={handleSearchSubmit}>

--- a/src/components/DAOs/shared/ConnectWalletToast.tsx
+++ b/src/components/DAOs/shared/ConnectWalletToast.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { toast } from "react-toastify";
+import { TextButton } from "../../ui/forms/Button";
+import { useWeb3 } from "../../../web3";
+import { connect } from "../../../web3/providers";
+
+const ToastContent = ({ label }: { label: string }) => {
+  return (
+    <div className="flex flex-col items-center">
+      <div>{label}</div>
+      <TextButton label="Connect Wallet" onClick={connect} />
+    </div>
+  );
+}
+
+const ConnectWalletToast = ({ label }: { label: string }) => {
+  const { account } = useWeb3();
+  useEffect(() => {
+    if (account) {
+      return;
+    }
+
+    const toastId = toast(<ToastContent label={label} />, {
+      autoClose: false,
+      closeOnClick: false,
+      draggable: false,
+      progress: 1,
+    });
+
+    return () => toast.dismiss(toastId);
+  }, [account, label]);
+
+  return null;
+};
+
+export default ConnectWalletToast;
+


### PR DESCRIPTION
Closes #164 

Extracts the "persistent toast" out of Create a DAO components and into it's own component, which can easily be added anywhere else, like the Search component here.

Also disables Search button unless account is connected.

<img width="1144" alt="Screen Shot 2022-05-04 at 12 32 57 AM" src="https://user-images.githubusercontent.com/706929/166623482-cdf73872-44ed-484c-a8c4-6fadeecc1451.png">

<img width="1143" alt="Screen Shot 2022-05-04 at 12 35 13 AM" src="https://user-images.githubusercontent.com/706929/166623617-40ca2189-3d0a-4d15-a935-a1e2200c3a1b.png">
