### PR TITLE
Data race safety

### DIFF
--- a/src/daoData/useAccessControlAddress.ts
+++ b/src/daoData/useAccessControlAddress.ts
@@ -1,20 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { DAO } from '../typechain-types';
+import useSafeRace from './useSafeRace';
 
 const useAccessControlAddress = (dao: DAO | undefined) => {
   const [accessControlAddress, setAccessControlAddress] = useState<string>();
 
-  useEffect(() => {
-    if (!dao) {
-      setAccessControlAddress(undefined);
-      return;
-    }
-
-    dao.accessControl()
-      .then(setAccessControlAddress)
-      .catch(console.error);
-  }, [dao]);
+  useSafeRace(
+    !dao,
+    () => setAccessControlAddress(undefined),
+    () => dao!.accessControl(),
+    (address) => setAccessControlAddress(address),
+  );
 
   return accessControlAddress;
 }

--- a/src/daoData/useDAOName.ts
+++ b/src/daoData/useDAOName.ts
@@ -1,20 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { DAO } from '../typechain-types';
+import useSafeRace from './useSafeRace';
 
 const useDAOName = (dao: DAO | undefined) => {
   const [name, setName] = useState<string>();
 
-  useEffect(() => {
-    if (!dao) {
-      setName(undefined);
-      return;
-    }
-
-    dao.name()
-      .then(setName)
-      .catch(console.error);
-  }, [dao]);
+  useSafeRace(
+    !dao,
+    () => setName(undefined),
+    () => dao!.name(),
+    (daoName) => setName(daoName),
+  );
 
   return name;
 }

--- a/src/daoData/useSafeRace.ts
+++ b/src/daoData/useSafeRace.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+function useSafeRace<T>(
+  earlyExitCondition: boolean,
+  earlyExitCallback: () => void,
+  asyncCallback: () => Promise<T>,
+  setStateCallback: (resolved: T) => void
+) {
+  useEffect(() => {
+    let pending = true;
+
+    if (earlyExitCondition) {
+      earlyExitCallback();
+      return;
+    }
+
+    asyncCallback()
+      .then((resolved) => {
+        if (pending) {
+          setStateCallback(resolved);
+        }
+      })
+      .catch(console.error)
+
+    return () => {
+      pending = false;
+    };
+  }, [earlyExitCondition, earlyExitCallback, asyncCallback, setStateCallback]);
+}
+
+export default useSafeRace;


### PR DESCRIPTION
# Background

The "data layer" in this app is very reactive, built using hooks. Hooks all the way down.

And all data comes from the initial "seed" of a DAO address. When the app is given some address, it'll use that to derive (in async network requests from teh blokchian) everything else it needs about the DAO data. The data layer can also be given an `undefined` address, which is a trigger to un-set all the state back to undefined. This is all achieved using patterns we've been implementing.

# Problem

But there's a funny lil race condition problem that manifests whenever the data layer is told about different addresses to load, too quickly back to back.

Imagine

The UI layer of the app tells the data layer "here's a DAO address, please load it all up". The data layer is now triggered to fire off seriously many dozens of async network requests. On a slow connection, these may take many seconds to all fully resolve. As network requests are resolved, different pieces of state are being updated with the resolved data.

However, imagine that immediately after the data layer starts making these network requests, the UI layer quickly tells it "jk, actually we don't want to load a DAO right now, here's `undefined`.

The data layer uses the `undefined` input as a flag to "set all the lil pieces of state to `undefined`, and early exit, don't make any network requests".

But like, that first round of network requests are still outstanding. And they're gonna get resolved in just a second. When they _do_ get resolved, there are no patterns in place for the data layer to recognize that these resolved requests are now "stale" and shouldn't be applied to the state.

# Solution

This PR is to put that pattern in place.

The simple solution is to include a `pending` or `loading` property in each piece of state's `useEffect` hook, which is true by default, is set to false in the `useEffect`'s return function, and whose value is checked after the network request resolves, only setting state if the property is still `true`. There are lots of blog posts online detailing this solution, see the first few results from this query: https://www.google.com/search?q=react+useeffect+async+race+condition

In this PR however, that pattern has been generalized into its own custom hook. Existing state hooks can replace their implementation with a call to `useSafeRace`, passing in the relevant implementation logic to `useSafeRace`'s various callback parameters.

# To do

This PR implements `useSafeRace` and uses it in two existing pieces of state.

Future PRs will be needed to continue replacing the rest of the async state setters throughout the data layer.