### PR TITLE
Delegation Component updates and fixes

### DIFF
--- a/src/components/DAOs/DAO/Delegate.tsx
+++ b/src/components/DAOs/DAO/Delegate.tsx
@@ -35,6 +35,16 @@ function Delegate() {
     successCallback: () => setNewDelegatee(""),
   });
 
+  const [readableBalance, setReadableBalance] = useState<string>();
+  useEffect(() => {
+    if (userBalance === undefined || decimals === undefined || symbol === undefined) {
+      setReadableBalance(undefined);
+      return;
+    }
+
+    setReadableBalance(`${utils.formatUnits(userBalance, decimals)} ${symbol}`);
+  }, [decimals, userBalance, symbol]);
+
   const [readableVotingWeight, setReadableVotingWeight] = useState<string>();
   useEffect(() => {
     if (votingWeight === undefined || decimals === undefined || symbol === undefined) {
@@ -65,7 +75,7 @@ function Delegate() {
           <div className="flex mx-2 my-1 text-gray-50">
             Balance:{" "}
             <span className="text-gray-25 ml-2">
-              <DataLoadingWrapper isLoading={userBalance === undefined || !symbol}>{`${userBalance} ${symbol}`}</DataLoadingWrapper>
+              <DataLoadingWrapper isLoading={readableBalance === undefined}>{readableBalance}</DataLoadingWrapper>
             </span>
           </div>
           <div className="flex mx-2 my-1 text-gray-50">

--- a/src/components/DAOs/DAO/Delegate.tsx
+++ b/src/components/DAOs/DAO/Delegate.tsx
@@ -35,6 +35,7 @@ function Delegate() {
   const delegateVote = useDelegateVote({
     delegatee: newDelegatee,
     setPending,
+    successCallback: () => setNewDelegatee(""),
   });
 
   const [readableVotingWeight, setReadableVotingWeight] = useState<string>();

--- a/src/components/DAOs/DAO/Delegate.tsx
+++ b/src/components/DAOs/DAO/Delegate.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { utils } from "ethers";
 import useDelegateVote from "../../../daoData/useDelegateVote";
 import useDisplayName from "../../../hooks/useDisplayName";
 import ContentBox from "../../ui/ContentBox";
@@ -18,11 +19,9 @@ function Delegate() {
   const [pending, setPending] = useState<boolean>(false);
   const [{ account }] = useWeb3();
   const [, validAddress] = useAddress(newDelegatee);
-  const [
-    {
-      tokenData: { symbol, userBalance, delegatee },
-    },
-  ] = useDAOData();
+  const [{
+    tokenData: { decimals, symbol, userBalance, delegatee, votingWeight }
+  }] = useDAOData();
   const delegateeDisplayName = useDisplayName(delegatee);
 
   const delegateSelf = () => {
@@ -37,6 +36,16 @@ function Delegate() {
     delegatee: newDelegatee,
     setPending,
   });
+
+  const [readableVotingWeight, setReadableVotingWeight] = useState<string>();
+  useEffect(() => {
+    if (votingWeight === undefined || decimals === undefined || symbol === undefined) {
+      setReadableVotingWeight(undefined);
+      return;
+    }
+
+    setReadableVotingWeight(`${utils.formatUnits(votingWeight, decimals)} ${symbol}`);
+  }, [decimals, votingWeight, symbol]);
 
   return (
     <>
@@ -69,6 +78,12 @@ function Delegate() {
                 <span className="text-gold-500 ml-2">{delegateeDisplayName}</span>
               </DataLoadingWrapper>
             </EtherscanLink>
+          </div>
+          <div className="flex mx-2 my-1 text-gray-50">
+            Current Voting Weight:{" "}
+            <span className="text-gray-25 ml-2">
+              <DataLoadingWrapper isLoading={readableVotingWeight === undefined}>{readableVotingWeight}</DataLoadingWrapper>
+            </span>
           </div>
           <SecondaryButton disabled={!validAddress || newDelegatee.trim() === ""} onClick={() => delegateVote()} label="Delegate" className="mt-4" />
         </ContentBox>

--- a/src/components/DAOs/DAO/Delegate.tsx
+++ b/src/components/DAOs/DAO/Delegate.tsx
@@ -59,7 +59,7 @@ function Delegate() {
           <div className="flex mx-2 my-1 text-gray-50">
             Balance:{" "}
             <span className="text-gray-25 ml-2">
-              <DataLoadingWrapper isLoading={!userBalance || !symbol}>{`${userBalance} ${symbol}`}</DataLoadingWrapper>
+              <DataLoadingWrapper isLoading={userBalance === undefined || !symbol}>{`${userBalance} ${symbol}`}</DataLoadingWrapper>
             </span>
           </div>
           <div className="flex mx-2 my-1 text-gray-50">

--- a/src/components/DAOs/DAO/Delegate.tsx
+++ b/src/components/DAOs/DAO/Delegate.tsx
@@ -4,7 +4,6 @@ import useDelegateVote from "../../../daoData/useDelegateVote";
 import useDisplayName from "../../../hooks/useDisplayName";
 import ContentBox from "../../ui/ContentBox";
 import EtherscanLink from "../../ui/EtherscanLink";
-import Pending from "../../Pending";
 import { useWeb3 } from "../../../web3";
 import { useDAOData } from "../../../daoData";
 import Input from "../../ui/forms/Input";
@@ -16,7 +15,6 @@ import DataLoadingWrapper from "../../ui/loaders/DataLoadingWrapper";
 
 function Delegate() {
   const [newDelegatee, setNewDelegatee] = useState<string>("");
-  const [pending, setPending] = useState<boolean>(false);
   const [{ account }] = useWeb3();
   const [, validAddress] = useAddress(newDelegatee);
   const [{
@@ -32,9 +30,8 @@ function Delegate() {
     setNewDelegatee(account);
   };
 
-  const delegateVote = useDelegateVote({
+  const [delegateVote, pending] = useDelegateVote({
     delegatee: newDelegatee,
-    setPending,
     successCallback: () => setNewDelegatee(""),
   });
 
@@ -50,7 +47,6 @@ function Delegate() {
 
   return (
     <>
-      <Pending message="Delegating Vote..." pending={pending} />
       <div className="flex flex-col bg-gray-600 my-4 p-2 py-2 rounded-md">
         <ContentBox title="Delegate Vote">
           <InputBox>
@@ -86,7 +82,7 @@ function Delegate() {
               <DataLoadingWrapper isLoading={readableVotingWeight === undefined}>{readableVotingWeight}</DataLoadingWrapper>
             </span>
           </div>
-          <SecondaryButton disabled={!validAddress || newDelegatee.trim() === ""} onClick={() => delegateVote()} label="Delegate" className="mt-4" />
+          <SecondaryButton disabled={!validAddress || newDelegatee.trim() === "" || pending} onClick={() => delegateVote()} label="Delegate" className="mt-4" />
         </ContentBox>
       </div>
     </>

--- a/src/components/ui/loaders/DataLoadingWrapper.tsx
+++ b/src/components/ui/loaders/DataLoadingWrapper.tsx
@@ -1,8 +1,6 @@
-import { ReactElement } from "react";
-
 interface DataLoadingWrapperProps {
   isLoading: boolean;
-  children: ReactElement<any, any> | string;
+  children: React.ReactNode;
 }
 /**
  *

--- a/src/daoData/daoData.ts
+++ b/src/daoData/daoData.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { BigNumber } from 'ethers';
 
 import useDAOContract from './useDAOContract';
 import useDAOName from './useDAOName';
@@ -27,6 +28,7 @@ export interface DAOData {
     decimals: number | undefined
     userBalance: number | undefined,
     delegatee: string | undefined,
+    votingWeight: BigNumber | undefined,
   },
   currentBlockNumber: number | undefined,
   currentTimestamp: number,

--- a/src/daoData/daoData.ts
+++ b/src/daoData/daoData.ts
@@ -26,7 +26,7 @@ export interface DAOData {
     name: string | undefined,
     symbol: string | undefined,
     decimals: number | undefined
-    userBalance: number | undefined,
+    userBalance: BigNumber | undefined,
     delegatee: string | undefined,
     votingWeight: BigNumber | undefined,
   },

--- a/src/daoData/useDelegateVote.ts
+++ b/src/daoData/useDelegateVote.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from 'react'
 import { useTransaction } from '../web3/transactions';
-import { useWeb3 } from '../web3';
 import { useDAOData } from './index';
 
 const useDelegateVote = ({
@@ -12,36 +11,27 @@ const useDelegateVote = ({
   setPending: React.Dispatch<React.SetStateAction<boolean>>
   successCallback: () => void,
 }) => {
-  const [{ signerOrProvider }] = useWeb3();
-  const [ daoData, ] = useDAOData();
+  const [{ tokenContract }] = useDAOData();
   const [contractCallDelegateVote, contractCallPending] = useTransaction();
-  const token = daoData.tokenContract;
 
   useEffect(() => {
     setPending(contractCallPending);
   }, [setPending, contractCallPending]);
 
   let delegateVote = useCallback(() => {
-    if (
-      signerOrProvider === undefined ||
-      setPending === undefined ||
-      token === undefined ||
-      delegatee === undefined
-    ) {
+    if (tokenContract === undefined || delegatee === undefined) {
       return;
     }
 
     contractCallDelegateVote({
-      contractFn: () => token.delegate(delegatee),
+      contractFn: () => tokenContract.delegate(delegatee),
       pendingMessage: "Delegating Vote",
       failedMessage: "Vote Delegation Failed",
       successMessage: "Vote Delegated",
-      rpcErrorCallback: (error: any) => {
-        console.error(error)
-      },
       successCallback: () => successCallback(),
     });
-  }, [contractCallDelegateVote, token, setPending, signerOrProvider, delegatee, successCallback])
+  }, [contractCallDelegateVote, tokenContract, delegatee, successCallback]);
+
   return delegateVote;
 }
 

--- a/src/daoData/useDelegateVote.ts
+++ b/src/daoData/useDelegateVote.ts
@@ -1,22 +1,16 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback } from 'react'
 import { useTransaction } from '../web3/transactions';
 import { useDAOData } from './index';
 
 const useDelegateVote = ({
   delegatee,
-  setPending,
   successCallback,
 }: {
   delegatee: string | undefined,
-  setPending: React.Dispatch<React.SetStateAction<boolean>>
   successCallback: () => void,
 }) => {
   const [{ tokenContract }] = useDAOData();
   const [contractCallDelegateVote, contractCallPending] = useTransaction();
-
-  useEffect(() => {
-    setPending(contractCallPending);
-  }, [setPending, contractCallPending]);
 
   let delegateVote = useCallback(() => {
     if (tokenContract === undefined || delegatee === undefined) {
@@ -32,7 +26,7 @@ const useDelegateVote = ({
     });
   }, [contractCallDelegateVote, tokenContract, delegatee, successCallback]);
 
-  return delegateVote;
+  return [delegateVote, contractCallPending] as const;
 }
 
 export default useDelegateVote;

--- a/src/daoData/useDelegateVote.ts
+++ b/src/daoData/useDelegateVote.ts
@@ -6,11 +6,12 @@ import { useDAOData } from './index';
 const useDelegateVote = ({
   delegatee,
   setPending,
+  successCallback,
 }: {
   delegatee: string | undefined,
   setPending: React.Dispatch<React.SetStateAction<boolean>>
-}
-) => {
+  successCallback: () => void,
+}) => {
   const [{ signerOrProvider }] = useWeb3();
   const [ daoData, ] = useDAOData();
   const [contractCallDelegateVote, contractCallPending] = useTransaction();
@@ -38,8 +39,9 @@ const useDelegateVote = ({
       rpcErrorCallback: (error: any) => {
         console.error(error)
       },
+      successCallback: () => successCallback(),
     });
-  }, [contractCallDelegateVote, token, setPending, signerOrProvider, delegatee])
+  }, [contractCallDelegateVote, token, setPending, signerOrProvider, delegatee, successCallback])
   return delegateVote;
 }
 

--- a/src/daoData/useTokenData.ts
+++ b/src/daoData/useTokenData.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect, useCallback } from "react";
 import { VotesTokenWithSupply } from "../typechain-types";
 import { useWeb3 } from "../web3";
-import { BigNumber, ethers } from "ethers";
+import { BigNumber } from "ethers";
 
 const useTokenData = (tokenContract: VotesTokenWithSupply | undefined) => {
   const [{ account }] = useWeb3();
   const [tokenName, setTokenName] = useState<string>();
   const [tokenSymbol, setTokenSymbol] = useState<string>();
   const [tokenDecimals, setTokenDecimals] = useState<number>();
-  const [tokenBalance, setTokenBalance] = useState<number>();
+  const [tokenBalance, setTokenBalance] = useState<BigNumber>();
   const [tokenDelegatee, setTokenDelegatee] = useState<string>();
   const [tokenVotingWeight, setTokenVotingWeight] = useState<BigNumber>();
 
@@ -20,13 +20,9 @@ const useTokenData = (tokenContract: VotesTokenWithSupply | undefined) => {
 
     tokenContract
       .balanceOf(account)
-      .then((balance) =>
-        setTokenBalance(
-          Number(ethers.utils.formatUnits(balance, tokenDecimals))
-        )
-      )
+      .then(setTokenBalance)
       .catch(console.error);
-  }, [account, tokenContract, tokenDecimals]);
+  }, [account, tokenContract]);
 
   // Get token name
   useEffect(() => {

--- a/src/web3/transactions.ts
+++ b/src/web3/transactions.ts
@@ -28,6 +28,7 @@ const useTransaction = () => {
       closeOnClick: false,
       draggable: false,
       closeButton: false,
+      progress: 1,
     });
     setPending(true);
 


### PR DESCRIPTION
Closes #130
Closes #154 

![Screen Shot 2022-05-04 at 3 33 58 PM](https://user-images.githubusercontent.com/706929/166812217-b157c4f7-afde-4948-956b-8352afe41b5f.png)

Changes include:

- Expose user token balance as a `BigNumber`, UI layer converts to human-readable string
- Remove full screen "transaction pending" modal from Delegate screen when transaction is in progress
  - rely on the toast to show outstanding transaction information
  - disable the Delegate button while transaction is outstanding
- add yellow bar to bottom of all "outstanding transaction" toasts
- after successful delegation transaction, clear out the Delegate address input box
- Add at-load and realtime-listener data fetching for getting the current account's voting weight (how much voting weight has been delegated to them), expose in `tokenData`
- Display the current account's voting weight on the Delegate page
- clean up the `useDelegateVote` hook a lot