### PR TITLE
Add proposal listeners

### DIFF
--- a/src/components/DAOs/DAO/Proposals/ProposalExecute.tsx
+++ b/src/components/DAOs/DAO/Proposals/ProposalExecute.tsx
@@ -14,7 +14,8 @@ function ProposalExecute({ proposal }: { proposal: ProposalData }) {
       return;
     }
 
-    setShow(proposal.eta !== 0 && proposal.eta < currentTimestamp);
+    // Show component if the proposal is Queued, and the execution ETA has elapsed
+    setShow(proposal.state === 5 && proposal.eta !== 0 && proposal.eta < currentTimestamp);
   }, [currentTimestamp, proposal]);
 
   const executeTransaction = useExecuteTransaction({

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -20,6 +20,9 @@ type ProposalDataWithoutUserData = {
   description: string;
   state: number | undefined;
   stateString: string | undefined;
+  forVotesCount: BigNumber | undefined;
+  againstVotesCount: BigNumber | undefined;
+  abstainVotesCount: BigNumber | undefined;
   forVotesPercent: number | undefined;
   againstVotesPercent: number | undefined;
   abstainVotesPercent: number | undefined;
@@ -170,6 +173,9 @@ const getProposalData = (
     proposal.endTimeString = getTimestampString(endTime);
     proposal.stateString = getStateString(proposal.state);
     proposal.eta = eta.toNumber();
+    proposal.forVotesCount = votes.forVotes;
+    proposal.againstVotesCount = votes.againstVotes;
+    proposal.abstainVotesCount = votes.abstainVotes;
 
     return proposal;
   });
@@ -331,6 +337,9 @@ const useProposalsWithoutUserData = (
             description: proposalEvent.args.description,
             state: undefined,
             stateString: undefined,
+            forVotesCount: undefined,
+            againstVotesCount: undefined,
+            abstainVotesCount: undefined,
             forVotesPercent: undefined,
             againstVotesPercent: undefined,
             abstainVotesPercent: undefined,
@@ -392,6 +401,9 @@ const useProposalsWithoutUserData = (
         description: description,
         state: undefined,
         stateString: undefined,
+        forVotesCount: undefined,
+        againstVotesCount: undefined,
+        abstainVotesCount: undefined,
         forVotesPercent: undefined,
         againstVotesPercent: undefined,
         abstainVotesPercent: undefined,
@@ -545,6 +557,9 @@ const useProposals = (
           description: proposal.description,
           state: proposal.state,
           stateString: proposal.stateString,
+          forVotesCount: proposal.forVotesCount,
+          againstVotesCount: proposal.againstVotesCount,
+          abstainVotesCount: proposal.abstainVotesCount,
           forVotesPercent: proposal.forVotesPercent,
           againstVotesPercent: proposal.againstVotesPercent,
           abstainVotesPercent: proposal.abstainVotesPercent,

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -466,8 +466,6 @@ const useProposalsWithoutUserData = (
     const filter = governorModule.filters.ProposalQueued();
 
     const listenerCallback = (proposalId: BigNumber, _: any) => {
-      console.log("Inside queued callback");
-
       governorModule
         .proposalEta(proposalId)
         .then((proposalEta) => {
@@ -505,7 +503,6 @@ const useProposalsWithoutUserData = (
     const filter = governorModule.filters.ProposalExecuted();
 
     const listenerCallback = (proposalId: BigNumber, _: any) => {
-      console.log("Inside executed callback");
       setProposalsWithoutUserData((existingProposals) => {
         if (existingProposals === undefined) {
           return undefined;
@@ -544,7 +541,6 @@ const useProposalsWithoutUserData = (
       weight: BigNumber,
       _: any
     ) => {
-      console.log("Inside vote cast callback");
       setProposalsWithoutUserData((existingProposals) => {
         if (existingProposals === undefined) {
           return undefined;
@@ -607,22 +603,23 @@ const useProposalsWithoutUserData = (
     if (currentBlockNumber === undefined) {
       return;
     }
-    console.log("CHecking state");
+
     setProposalsWithoutUserData((existingProposals) => {
-      if(existingProposals === undefined) return undefined;
+      if (existingProposals === undefined) return undefined;
 
       return existingProposals.map((existingProposal) => {
         const newProposal = existingProposal;
-        if(newProposal.state === 0 && newProposal.startBlock.toNumber() <= currentBlockNumber) {
-          console.log("Updating state");
+        if (
+          newProposal.state === 0 &&
+          newProposal.startBlock.toNumber() <= currentBlockNumber
+        ) {
           newProposal.state = 1;
           newProposal.stateString = getStateString(1);
         }
 
         return newProposal;
-      })
+      });
     });
-
   }, [currentBlockNumber]);
 
   return proposalsWithoutUserData;
@@ -630,10 +627,13 @@ const useProposalsWithoutUserData = (
 
 const useProposals = (
   governorModule: GovernorModule | undefined,
-  currentBlockNumber: number | undefined,
+  currentBlockNumber: number | undefined
 ) => {
   const userVotes = useUserVotes(governorModule);
-  const proposalsWithoutUserData = useProposalsWithoutUserData(currentBlockNumber, governorModule);
+  const proposalsWithoutUserData = useProposalsWithoutUserData(
+    currentBlockNumber,
+    governorModule
+  );
   const userVotePowers = useUserVotePowers(
     proposalsWithoutUserData,
     governorModule,

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -324,6 +324,7 @@ const useUserVotePowers = (
 };
 
 const useProposalsWithoutUserData = (
+  currentBlockNumber: number | undefined,
   governorModule: GovernorModule | undefined
 ) => {
   const [{ provider }] = useWeb3();
@@ -601,15 +602,38 @@ const useProposalsWithoutUserData = (
     };
   }, [governorModule]);
 
+  // Check for pending proposals that have become active
+  useEffect(() => {
+    if (currentBlockNumber === undefined) {
+      return;
+    }
+    console.log("CHecking state");
+    setProposalsWithoutUserData((existingProposals) => {
+      if(existingProposals === undefined) return undefined;
+
+      return existingProposals.map((existingProposal) => {
+        const newProposal = existingProposal;
+        if(newProposal.state === 0 && newProposal.startBlock.toNumber() <= currentBlockNumber) {
+          console.log("Updating state");
+          newProposal.state = 1;
+          newProposal.stateString = getStateString(1);
+        }
+
+        return newProposal;
+      })
+    });
+
+  }, [currentBlockNumber]);
+
   return proposalsWithoutUserData;
 };
 
 const useProposals = (
   governorModule: GovernorModule | undefined,
-  currentBlockNumber: number | undefined
+  currentBlockNumber: number | undefined,
 ) => {
   const userVotes = useUserVotes(governorModule);
-  const proposalsWithoutUserData = useProposalsWithoutUserData(governorModule);
+  const proposalsWithoutUserData = useProposalsWithoutUserData(currentBlockNumber, governorModule);
   const userVotePowers = useUserVotePowers(
     proposalsWithoutUserData,
     governorModule,

--- a/src/daoData/useProposals.ts
+++ b/src/daoData/useProposals.ts
@@ -136,11 +136,11 @@ const getUserVotePower = (
 const getVotePercentages = (
   againstVotesCount: BigNumber | undefined,
   forVotesCount: BigNumber | undefined,
-  abstainVotesCount: BigNumber | undefined,
+  abstainVotesCount: BigNumber | undefined
 ) => {
-  if(againstVotesCount === undefined) againstVotesCount = BigNumber.from("0");
-  if(forVotesCount === undefined) forVotesCount = BigNumber.from("0");
-  if(abstainVotesCount === undefined) abstainVotesCount = BigNumber.from("0");
+  if (againstVotesCount === undefined) againstVotesCount = BigNumber.from("0");
+  if (forVotesCount === undefined) forVotesCount = BigNumber.from("0");
+  if (abstainVotesCount === undefined) abstainVotesCount = BigNumber.from("0");
 
   const totalVotes = againstVotesCount
     .add(forVotesCount)
@@ -154,11 +154,14 @@ const getVotePercentages = (
     };
   }
   return {
-    againstVotesPercent: againstVotesCount.mul(1000000).div(totalVotes).toNumber() / 10000,
-    forVotesPercent: forVotesCount.mul(1000000).div(totalVotes).toNumber() / 10000,
-    abstainVotesPercent: abstainVotesCount.mul(1000000).div(totalVotes).toNumber() / 10000,
+    againstVotesPercent:
+      againstVotesCount.mul(1000000).div(totalVotes).toNumber() / 10000,
+    forVotesPercent:
+      forVotesCount.mul(1000000).div(totalVotes).toNumber() / 10000,
+    abstainVotesPercent:
+      abstainVotesCount.mul(1000000).div(totalVotes).toNumber() / 10000,
   };
-}
+};
 
 // Get proposal data that isn't included in the proposal created event
 const getProposalData = (
@@ -174,21 +177,15 @@ const getProposalData = (
     governorModule.proposalEta(proposal.id),
     proposal,
   ]).then(([votes, state, startTime, endTime, eta, proposal]) => {
-    const totalVotes = votes.forVotes
-      .add(votes.againstVotes)
-      .add(votes.abstainVotes);
-    if (totalVotes.gt(0)) {
-      proposal.forVotesPercent =
-        votes.forVotes.mul(1000000).div(totalVotes).toNumber() / 10000;
-      proposal.againstVotesPercent =
-        votes.againstVotes.mul(1000000).div(totalVotes).toNumber() / 10000;
-      proposal.abstainVotesPercent =
-        votes.abstainVotes.mul(1000000).div(totalVotes).toNumber() / 10000;
-    } else {
-      proposal.forVotesPercent = 0;
-      proposal.againstVotesPercent = 0;
-      proposal.abstainVotesPercent = 0;
-    }
+    const votePercentages = getVotePercentages(
+      votes.againstVotes,
+      votes.forVotes,
+      votes.abstainVotes
+    );
+
+    proposal.againstVotesPercent = votePercentages.againstVotesPercent;
+    proposal.forVotesPercent = votePercentages.forVotesPercent;
+    proposal.abstainVotesPercent = votePercentages.abstainVotesPercent;
 
     proposal.idSubstring = `${proposal.id
       .toString()
@@ -560,7 +557,6 @@ const useProposalsWithoutUserData = (
         const newProposal = newProposals[updatedProposalIndex];
 
         if (support === 0) {
-
           if (newProposal.againstVotesCount === undefined) {
             newProposal.againstVotesCount = weight;
           } else {
@@ -571,8 +567,7 @@ const useProposalsWithoutUserData = (
           if (newProposal.forVotesCount === undefined) {
             newProposal.forVotesCount = weight;
           } else {
-            newProposal.forVotesCount =
-              newProposal.forVotesCount.add(weight);
+            newProposal.forVotesCount = newProposal.forVotesCount.add(weight);
           }
         } else {
           if (newProposal.abstainVotesCount === undefined) {
@@ -583,7 +578,11 @@ const useProposalsWithoutUserData = (
           }
         }
 
-        const votePercentages = getVotePercentages(newProposal.againstVotesCount, newProposal.forVotesCount, newProposal.abstainVotesCount);
+        const votePercentages = getVotePercentages(
+          newProposal.againstVotesCount,
+          newProposal.forVotesCount,
+          newProposal.abstainVotesCount
+        );
 
         newProposal.againstVotesPercent = votePercentages.againstVotesPercent;
         newProposal.forVotesPercent = votePercentages.forVotesPercent;


### PR DESCRIPTION
This PR updates the useProposals hook to support:
 - Add voteCounts to ProposalData object
 - Only show the ProposalExecute component when the proposal is queued
 - Update voteCounts and votePercentages as new vote cast events are emitted
 - Update proposal state from pending to active when the proposal start block passes