### PR TITLE
Handle Network Change on DAO Route

### DIFF
--- a/src/components/DAOs/DAO/index.tsx
+++ b/src/components/DAOs/DAO/index.tsx
@@ -78,9 +78,9 @@ function Search() {
 function DAO() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [{ account, accountLoading }] = useWeb3();
+  const [{ account, accountLoading, chainId }] = useWeb3();
   const [, setAddress] = useDAOData();
-
+  
   const [validatedAddress, setValidatedAddress] = useState((location.state as { validatedAddress: string } | null)?.validatedAddress);
   useEffect(() => {
     if (!location || !location.state) {
@@ -103,6 +103,8 @@ function DAO() {
 
   // when this component unloads, setAddress back to undefined to clear app state
   useEffect(() => () => setAddress(undefined), [setAddress]);
+  // if network changes remove address validation.
+  useEffect(() => () => setValidatedAddress(undefined), [chainId])
 
   if (validatedAddress) {
     return <ValidDAO address={validatedAddress} />;

--- a/src/components/DAOs/DAO/index.tsx
+++ b/src/components/DAOs/DAO/index.tsx
@@ -80,7 +80,7 @@ function DAO() {
   const navigate = useNavigate();
   const [{ account, accountLoading, chainId }] = useWeb3();
   const [, setAddress] = useDAOData();
-  
+
   const [validatedAddress, setValidatedAddress] = useState((location.state as { validatedAddress: string } | null)?.validatedAddress);
   useEffect(() => {
     if (!location || !location.state) {
@@ -104,7 +104,7 @@ function DAO() {
   // when this component unloads, setAddress back to undefined to clear app state
   useEffect(() => () => setAddress(undefined), [setAddress]);
   // if network changes remove address validation.
-  useEffect(() => () => setValidatedAddress(undefined), [chainId])
+  useEffect(() => () => setValidatedAddress(undefined), [chainId]);
 
   if (validatedAddress) {
     return <ValidDAO address={validatedAddress} />;


### PR DESCRIPTION
closes #182 

## Overview
Adds a useEffect to fire when networkId is changed. reloading component and running address validating again. This would cause the user to be navigating back to "/" with toast error of "fractal doesn't exists"