### PR TITLE
Add IPFS dev workflow

### DIFF
--- a/.github/workflows/release-ipfs-dev.yaml
+++ b/.github/workflows/release-ipfs-dev.yaml
@@ -1,0 +1,52 @@
+name: Release IPFS Dev
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  create_release:
+    name: Create IPFS Release
+
+    runs-on: ubuntu-latest
+
+    environment: dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up node
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install and Build
+        run: |
+          npm install
+          npm run build
+
+      - name: IPFS Pinata deploy GitHub action
+        uses: anantaramdas/ipfs-pinata-deploy-action@v1.6.3
+        id: upload
+        with:
+          pin-name: ${{ secrets.PINATA_PIN_NAME }}
+          path: './build'
+          pinata-api-key: ${{ secrets.PINATA_API_KEY }}
+          pinata-secret-api-key: ${{ secrets.PINATA_API_SECRET_KEY }}
+
+      - name: Convert CIDv0 to CIDv1
+        id: convert_cidv0
+        uses: uniswap/convert-cidv0-cidv1@v1.0.0
+        with:
+          cidv0: ${{ steps.upload.outputs.hash }}
+
+      - name: Update DNS with new IPFS hash
+        uses: textileio/cloudflare-update-dnslink@v2
+        with:
+          cid: ${{ steps.convert_cidv0.outputs.cidv1 }}
+        env:
+          CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
+          RECORD_DOMAIN: ${{ secrets.CLOUDFLARE_DOMAIN_NAME }}
+          RECORD_NAME: ${{ secrets.CLOUDFLARE_RECORD_NAME }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}


### PR DESCRIPTION
Closes #121 

if you have an IPFS node running (i do on my macbook, easy as brew install ipfs)

and the IPFS chrome extension installed

then simply going to app.dev.fractalframework.xyz will redirect you to app.dev.fractalframework.xyz.ipns.localhost:8080

which hosts the site directly from your local IPFS node

the way that works is:

- i created a github action
- that is triggered whenever a build happens
- what it does is
  - build the app
  - upload the build folder to pinata.cloud
  - pin the files
  - get the resulting IPFS hash
  - update a DNS TXT record (_dnslink.app.dev.fractalframework.xyz) with the appropriate value (dnslink=/ipfs/<hash>)
  - the existence of that record is what allows the IPFS browser extension to redirect to your local IPFS node and serve locally