### PR TITLE
Publish git hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "web3modal": "^1.9.5"
   },
   "scripts": {
-    "start": "GENERATE_SOURCEMAP=false react-app-rewired start",
+    "start": "GENERATE_SOURCEMAP=false REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired start",
     "start:windows": "set \"GENERATE_SOURCEMAP=false\" && react-app-rewired start",
-    "build": "react-app-rewired build",
-    "test": "react-app-rewired test",
+    "build": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired build",
+    "test": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired test",
     "eject": "react-app-rewired eject"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "start": "GENERATE_SOURCEMAP=false REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired start",
     "start:windows": "set \"GENERATE_SOURCEMAP=false\" && for /F \"delims=\" %I in ('git rev-parse HEAD') do set \"REACT_APP_GIT_HASH=%I\" && react-app-rewired start",
     "build": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired build",
+    "build:windows": "for /F \"delims=\" %I in ('git rev-parse HEAD') do set \"REACT_APP_GIT_HASH=%I\" && react-app-rewired build",
     "test": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired test",
     "eject": "react-app-rewired eject"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "fractal-interface",
-  "version": "0.1.0",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "start": "GENERATE_SOURCEMAP=false REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired start",
-    "start:windows": "set \"GENERATE_SOURCEMAP=false\" && react-app-rewired start",
+    "start:windows": "set \"GENERATE_SOURCEMAP=false\" && for /F \"delims=\" %I in ('git rev-parse HEAD') do set \"REACT_APP_GIT_HASH=%I\" && react-app-rewired start",
     "build": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired build",
     "test": "REACT_APP_GIT_HASH=`git rev-parse HEAD` react-app-rewired test",
     "eject": "react-app-rewired eject"

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Fractal Framework scales with you"
+      content="Do More with DAOs. Go farther, faster. Create a hyper-scalable global organization. Fractalize risk and governance."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Do More with DAOs. Go farther, faster. Create a hyper-scalable global organization. Fractalize risk and governance."
     />
+    <meta name="git-hash" content="%REACT_APP_GIT_HASH%" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
In app start/build scripts, use git to capture the current git hash.
Put that git hash in an environment variable.
Stick that environment variable in a `meta` tag in the `head`.