### PR TITLE
removes extra margin

### DIFF
--- a/src/components/Proposals/CastVote.tsx
+++ b/src/components/Proposals/CastVote.tsx
@@ -35,7 +35,7 @@ function CastVote({ proposal }: { proposal: ProposalData }) {
   const AbstainedSelected = () => (newVote === 2 || proposal.userVote === 2 ? <Check /> : null);
   return (
     <>
-      <div className="flex flex-col bg-gray-600 m-2 p-2 pb-4 w-3/5 rounded-md">
+      <div className="flex flex-col bg-gray-600 my-2 p-2 pb-4 w-3/5 rounded-md">
         <div className="flex mx-2 my-2 text-gray-25 text-lg font-semibold">Cast Vote</div>
         <hr className="mx-2 mb-6 border-gray-200" />
         <div className="flex flex-col gap-4">

--- a/src/components/Proposals/ProposalCardDetailed.tsx
+++ b/src/components/Proposals/ProposalCardDetailed.tsx
@@ -9,7 +9,7 @@ import StatusBox from "../ui/StatusBox";
 
 function ProposalCardDetailed({ proposal }: { proposal: ProposalData }) {
   return (
-    <div className="mx-2">
+    <div>
       <ContentBox >
         <div className="flex items-center">
           <StatusBox status={proposal.stateString} />

--- a/src/components/Proposals/ProposalDetails.tsx
+++ b/src/components/Proposals/ProposalDetails.tsx
@@ -34,7 +34,7 @@ function ProposalDetails() {
   }
 
   return (
-    <div className="flex flex-col">
+    <div>
       <ProposalQueue proposal={proposal} />
       <ProposalExecute proposal={proposal} />
       <ProposalCardDetailed proposal={proposal} />

--- a/src/components/Proposals/ProposalVotes.tsx
+++ b/src/components/Proposals/ProposalVotes.tsx
@@ -11,7 +11,7 @@ const VotesPercentage = ({ label, percentage }: { label: string; percentage?: nu
 
 function ProposalVotes({ proposal }: { proposal: ProposalData }) {
   return (
-    <div className="flex flex-grow flex-col h-full bg-gray-600 m-2 p-2 pb-4 rounded-md">
+    <div className="flex flex-grow flex-col h-full bg-gray-600 my-2 ml-4 p-2 pb-4 rounded-md">
       <div className="flex mx-2 my-2 text-gray-25 mb-3 text-lg font-semibold">Results</div>
       <VotesPercentage label="Yes" percentage={proposal.forVotesPercent} />
 


### PR DESCRIPTION
closes #225 

Based off #251 

## Overview
Cleans up margin so DAO Summary and Proposal screen containers match

## Screenshot
![image](https://user-images.githubusercontent.com/38386583/167412780-763b9c32-bc06-49f5-b963-c8c9606b9e3b.png)
