### PR TITLE
Proposal state enum

### DIFF
--- a/src/components/Proposals/CastVote.tsx
+++ b/src/components/Proposals/CastVote.tsx
@@ -1,4 +1,4 @@
-import { ProposalData } from "../../contexts/daoData/useProposals";
+import { ProposalData, ProposalState } from "../../contexts/daoData/useProposals";
 import { useState, useEffect } from "react";
 import useCastVote from "../../hooks/useCastVote";
 import { PrimaryButton, SecondaryButton } from "../ui/forms/Button";
@@ -15,7 +15,7 @@ function CastVote({ proposal }: { proposal: ProposalData }) {
   const [pending, setPending] = useState<boolean>(false);
 
   useEffect(() => {
-    if (proposal.state !== 1) {
+    if (proposal.state !== ProposalState.Active) {
       setVoteButtonString("Voting Closed");
     } else if (proposal.userVote !== undefined) {
       setVoteButtonString("Already Voted");
@@ -45,7 +45,7 @@ function CastVote({ proposal }: { proposal: ProposalData }) {
             onClick={() => setNewVote(1)}
             icon={<YesSelected />}
             disabled={
-              proposal.state !== 1 || 
+              proposal.state !== ProposalState.Active || 
               proposal.userVote !== undefined || 
               proposal.userVotePower === undefined || 
               proposal.userVotePower.eq(0) ||
@@ -60,7 +60,7 @@ function CastVote({ proposal }: { proposal: ProposalData }) {
             onClick={() => setNewVote(0)}
             icon={<NoSelected />}
             disabled={
-              proposal.state !== 1 || 
+              proposal.state !== ProposalState.Active || 
               proposal.userVote !== undefined || 
               proposal.userVotePower === undefined || 
               proposal.userVotePower.eq(0) ||
@@ -75,7 +75,7 @@ function CastVote({ proposal }: { proposal: ProposalData }) {
             onClick={() => setNewVote(2)}
             icon={<AbstainedSelected />}
             disabled={
-              proposal.state !== 1 || 
+              proposal.state !== ProposalState.Active || 
               proposal.userVote !== undefined || 
               proposal.userVotePower === undefined || 
               proposal.userVotePower.eq(0) ||
@@ -91,7 +91,7 @@ function CastVote({ proposal }: { proposal: ProposalData }) {
             onClick={() => castVote()}
             disabled={
               newVote === undefined ||
-              proposal.state !== 1 ||
+              proposal.state !== ProposalState.Active ||
               proposal.userVote !== undefined ||
               proposal.userVotePower === undefined ||
               proposal.userVotePower.eq(0) ||

--- a/src/components/Proposals/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard.tsx
@@ -12,7 +12,7 @@ function ProposalCard({ proposal }: { proposal: ProposalData }) {
     <Link to={`proposals/${proposal.number}`}>
       <ContentBox isLightBackground>
         <div className="flex items-center">
-          <StatusBox status={proposal.stateString} />
+          <StatusBox status={proposal.state} />
           <ProposalNumber
             proposalNumber={proposal.number}
             textSize="text-sm"

--- a/src/components/Proposals/ProposalCardDetailed.tsx
+++ b/src/components/Proposals/ProposalCardDetailed.tsx
@@ -12,7 +12,7 @@ function ProposalCardDetailed({ proposal }: { proposal: ProposalData }) {
     <div>
       <ContentBox >
         <div className="flex items-center">
-          <StatusBox status={proposal.stateString} />
+          <StatusBox status={proposal.state} />
           <ProposalNumber
             proposalNumber={proposal.number}
           />

--- a/src/components/Proposals/ProposalExecute.tsx
+++ b/src/components/Proposals/ProposalExecute.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ProposalData } from "../../contexts/daoData/useProposals";
+import { ProposalData, ProposalState } from "../../contexts/daoData/useProposals";
 import useExecuteTransaction from "../../hooks/useExecuteTransaction";
 import { PrimaryButton } from "../ui/forms/Button";
 import { useBlockchainData } from "../../contexts/blockchainData";
@@ -16,7 +16,7 @@ function ProposalExecute({ proposal }: { proposal: ProposalData }) {
     }
 
     // Show component if the proposal is Queued, and the execution ETA has elapsed
-    setShow(proposal.state === 5 && proposal.eta !== 0 && proposal.eta < currentTimestamp);
+    setShow(proposal.state === ProposalState.Queued && proposal.eta !== 0 && proposal.eta < currentTimestamp);
   }, [currentTimestamp, proposal]);
 
   const executeTransaction = useExecuteTransaction({

--- a/src/components/Proposals/ProposalQueue.tsx
+++ b/src/components/Proposals/ProposalQueue.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ProposalData } from "../../contexts/daoData/useProposals";
+import { ProposalData, ProposalState } from "../../contexts/daoData/useProposals";
 import useQueueTransaction from "../../hooks/useQueueTransaction";
 import { PrimaryButton } from "../ui/forms/Button";
 
@@ -11,7 +11,7 @@ function ProposalQueue({ proposal }: { proposal: ProposalData }) {
     setPending
   });
 
-  if (proposal.stateString !== "Succeeded") {
+  if (proposal.state !== ProposalState.Succeeded) {
     return null;
   }
 

--- a/src/components/ui/StatusBox.tsx
+++ b/src/components/ui/StatusBox.tsx
@@ -1,13 +1,17 @@
 import cx from "classnames";
+import { ProposalState } from "../../contexts/daoData/useProposals";
+import useProposalStateString from "../../hooks/useProposalStateString";
 
 interface StatusBoxProps {
-  status?: string;
+  status?: ProposalState;
 }
 
 const StatusBox = ({ status }: StatusBoxProps) => {
+  const proposalState = useProposalStateString(status);
+
   const getStatusColors = () => {
     switch (status) {
-      case "Active":
+      case ProposalState.Active:
         return "bg-drab-500 text-gold-500";
       default:
         return "border border-gray-50 text-gray-50 bg-gray-400";
@@ -15,7 +19,7 @@ const StatusBox = ({ status }: StatusBoxProps) => {
   };
   return (
     <div className={cx("px-2 py-0.5 rounded-full font-medium text-xs h-fit", getStatusColors())}>
-      <div>{status}</div>
+      <div>{proposalState}</div>
     </div>
   );
 };

--- a/src/contexts/daoData/useProposals.ts
+++ b/src/contexts/daoData/useProposals.ts
@@ -30,7 +30,6 @@ type ProposalDataWithoutUserData = {
   calldatas: string[];
   description: string;
   state: ProposalState | undefined;
-  stateString: string | undefined;
   forVotesCount: BigNumber | undefined;
   againstVotesCount: BigNumber | undefined;
   abstainVotesCount: BigNumber | undefined;
@@ -64,26 +63,6 @@ const getVoteString = (voteNumber: number) => {
     return "Abstain";
   } else {
     return undefined;
-  }
-};
-
-const getStateString = (state: number | undefined) => {
-  if (state === 0) {
-    return "Pending";
-  } else if (state === 1) {
-    return "Active";
-  } else if (state === 2) {
-    return "Canceled";
-  } else if (state === 3) {
-    return "Defeated";
-  } else if (state === 4) {
-    return "Succeeded";
-  } else if (state === 5) {
-    return "Queued";
-  } else if (state === 6) {
-    return "Expired";
-  } else if (state === 7) {
-    return "Executed";
   }
 };
 
@@ -206,7 +185,6 @@ const getProposalData = (
     proposal.endTime = endTime;
     proposal.startTimeString = getTimestampString(startTime);
     proposal.endTimeString = getTimestampString(endTime);
-    proposal.stateString = getStateString(proposal.state);
     proposal.eta = eta.toNumber();
     proposal.forVotesCount = votes.forVotes;
     proposal.againstVotesCount = votes.againstVotes;
@@ -372,7 +350,6 @@ const useProposalsWithoutUserData = (
             calldatas: proposalEvent.args.calldatas,
             description: proposalEvent.args.description,
             state: undefined,
-            stateString: undefined,
             forVotesCount: undefined,
             againstVotesCount: undefined,
             abstainVotesCount: undefined,
@@ -436,7 +413,6 @@ const useProposalsWithoutUserData = (
         calldatas: calldatas,
         description: description,
         state: undefined,
-        stateString: undefined,
         forVotesCount: undefined,
         againstVotesCount: undefined,
         abstainVotesCount: undefined,
@@ -490,7 +466,6 @@ const useProposalsWithoutUserData = (
             );
             const newProposals = [...existingProposals];
             newProposals[updatedProposalIndex].state = ProposalState.Queued;
-            newProposals[updatedProposalIndex].stateString = getStateString(ProposalState.Queued);
             newProposals[updatedProposalIndex].eta = proposalEta.toNumber();
             return newProposals;
           });
@@ -524,7 +499,6 @@ const useProposalsWithoutUserData = (
         );
         const newProposals = [...existingProposals];
         newProposals[updatedProposalIndex].state = ProposalState.Executed;
-        newProposals[updatedProposalIndex].stateString = getStateString(ProposalState.Executed);
         return newProposals;
       });
     };
@@ -625,7 +599,6 @@ const useProposalsWithoutUserData = (
           newProposal.startBlock.toNumber() <= currentBlockNumber
         ) {
           newProposal.state = ProposalState.Active;
-          newProposal.stateString = getStateString(ProposalState.Active);
         }
 
         return newProposal;
@@ -689,7 +662,6 @@ const useProposals = (
           calldatas: proposal.calldatas,
           description: proposal.description,
           state: proposal.state,
-          stateString: proposal.stateString,
           forVotesCount: proposal.forVotesCount,
           againstVotesCount: proposal.againstVotesCount,
           abstainVotesCount: proposal.abstainVotesCount,

--- a/src/contexts/daoData/useProposals.ts
+++ b/src/contexts/daoData/useProposals.ts
@@ -3,6 +3,17 @@ import { GovernorModule } from "../../typechain-types";
 import { useWeb3 } from "../web3Data";
 import { BigNumber, providers } from "ethers";
 
+export enum ProposalState {
+  Pending = 0,
+  Active = 1,
+  Canceled = 2,
+  Defeated = 3,
+  Succeeded = 4,
+  Queued = 5,
+  Expired = 6,
+  Executed = 7,
+}
+
 type ProposalDataWithoutUserData = {
   number: number;
   id: BigNumber;
@@ -18,7 +29,7 @@ type ProposalDataWithoutUserData = {
   signatures: string[];
   calldatas: string[];
   description: string;
-  state: number | undefined;
+  state: ProposalState | undefined;
   stateString: string | undefined;
   forVotesCount: BigNumber | undefined;
   againstVotesCount: BigNumber | undefined;
@@ -478,8 +489,8 @@ const useProposalsWithoutUserData = (
               (proposal) => proposalId.eq(proposal.id)
             );
             const newProposals = [...existingProposals];
-            newProposals[updatedProposalIndex].state = 5;
-            newProposals[updatedProposalIndex].stateString = getStateString(5);
+            newProposals[updatedProposalIndex].state = ProposalState.Queued;
+            newProposals[updatedProposalIndex].stateString = getStateString(ProposalState.Queued);
             newProposals[updatedProposalIndex].eta = proposalEta.toNumber();
             return newProposals;
           });
@@ -512,8 +523,8 @@ const useProposalsWithoutUserData = (
           proposalId.eq(proposal.id)
         );
         const newProposals = [...existingProposals];
-        newProposals[updatedProposalIndex].state = 7;
-        newProposals[updatedProposalIndex].stateString = getStateString(7);
+        newProposals[updatedProposalIndex].state = ProposalState.Executed;
+        newProposals[updatedProposalIndex].stateString = getStateString(ProposalState.Executed);
         return newProposals;
       });
     };
@@ -610,11 +621,11 @@ const useProposalsWithoutUserData = (
       return existingProposals.map((existingProposal) => {
         const newProposal = existingProposal;
         if (
-          newProposal.state === 0 &&
+          newProposal.state === ProposalState.Pending &&
           newProposal.startBlock.toNumber() <= currentBlockNumber
         ) {
-          newProposal.state = 1;
-          newProposal.stateString = getStateString(1);
+          newProposal.state = ProposalState.Active;
+          newProposal.stateString = getStateString(ProposalState.Active);
         }
 
         return newProposal;

--- a/src/hooks/useProposalStateString.ts
+++ b/src/hooks/useProposalStateString.ts
@@ -1,0 +1,17 @@
+import { ProposalState } from "../contexts/daoData/useProposals";
+
+const useProposalStateString = (state: ProposalState | undefined) => {
+  switch (state) {
+    case ProposalState.Pending: return "Pending";
+    case ProposalState.Active: return "Active";
+    case ProposalState.Canceled: return "Canceled";
+    case ProposalState.Defeated: return "Defeated";
+    case ProposalState.Succeeded: return "Succeeded";
+    case ProposalState.Queued: return "Queued";
+    case ProposalState.Expired: return "Expired";
+    case ProposalState.Executed: return "Executed";
+    default: return "Unknown";
+  }
+}
+
+export default useProposalStateString;


### PR DESCRIPTION
Closes #249 

- Creates an enum type called `ProposalState` with the 8 states a proposal might be in.
- Updates the type of `state` in `ProposalData` from a `number` to `ProposalState`.
- Creates a hook for taking a `ProposalState` input and returning a string representation.
- Updates all UI components to no longer use `stateString`, but instead to logical comparisons using `state`, and visual display of state using the new hook.
- Removes `stateString` from `ProposalData`, instead exposing just `state`.

As always, the commits, when viewed in order, tell a story of the changes.